### PR TITLE
Operators applied to Structures

### DIFF
--- a/src/sicmutils/structure.clj
+++ b/src/sicmutils/structure.clj
@@ -139,6 +139,13 @@
         (vector? s) (mapv #(mapr f %) s)
         :else (f s)))
 
+;; scmutils favours this (vector-map f struct) - might need to shim mapv, but acceptable for now
+;; currently used mainly in Operator ***AG***
+(defn map-struct
+  "return the result of a mapping onto a structure"
+  [f s]
+  (same s (map f s)))
+        
 (defn structure->access-chains
   "Return a structure of the same shape as s whose elements are access
   chains corresponding to position of each element (i.e., the sequence

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -87,7 +87,7 @@
            (((partial 1) ((partial 0) ff)) 'x 'y))))
            
   (testing "negation of Operator"
-    (is (= (((* (- (- D))) ff) 'x 'y)  (((* (- (- D))) ff) 'x 'y))))
+    (is (= (((* (- (- D))) ff) 'x 'y)  (( D ff) 'x 'y))))
 
   (testing "Addition of Operator and Structure (for multivariate literal-functions)"
     (is (= (((+ (expt D 2) D 1) ff) 1 2)

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -15,6 +15,23 @@
 ; You should have received a copy of the GNU General Public License
 ; along with this code; if not, see <http://www.gnu.org/licenses/>.
 ;
+;
+; Copyright (C) 2016 Colin Smith.
+; This work is based on the Scmutils system of MIT/GNU Scheme.
+;
+; This is free software;  you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation; either version 3 of the License, or (at
+; your option) any later version.
+;
+; This software is distributed in the hope that it will be useful, but
+; WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+; General Public License for more details.
+;
+; You should have received a copy of the GNU General Public License
+; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;
 
 (ns sicmutils.operator-test
   (:refer-clojure :exclude [+ - * / zero? partial])
@@ -23,10 +40,11 @@
             [sicmutils.operator :refer :all]
             ))
 
-(def ^:private f (literal-function 'f))
-(def ^:private g (literal-function 'g))
-(def ^:private ff (literal-function 'ff [0 0] 0))
-(def ^:private gg (literal-function 'gg [0 0] 0))
+; make private?            
+(def f (literal-function 'f))
+(def g (literal-function 'g))
+(def ff (literal-function 'ff [0 0] 0))
+(def gg (literal-function 'gg [0 0] 0))
 
 
 ;; Test operations with Operators
@@ -37,50 +55,11 @@
     )
   (testing "that they compose with other Operators"
     (is (every? operator? [(* D D)(* D (partial 0))(*(partial 0) D)(* (partial 0)(partial 1))])))
-<<<<<<< HEAD
-
-;; not run through Travis yet    
-    
   (testing "that multiplication of Operators is equivalent to application/composition"           
      (is (= (((* D D) ff) 'x 'y) 
             ((D (D ff))'x 'y)))
      (is (= (((* (partial 0)(partial 1)) ff)'x 'y) 
             (((partial 0) ((partial 1) ff))'x 'y))))
-            
-;; ---------------------            
-
-  (comment testing "that their arithmetic operations compose correctly, as per SICM -  'Our Notation'"
-      (is (= (((* (+ D 1)(- D 1)) f) 'x) 
-             (+ (((expt D 2) f) 'x) (* -1 (f 'x))))))
-
-  (comment testing "that Operators compose correctly with functions"
-      (is (= ((D ((* (- D g)(+ D 1)) f)) 'x)
-	     (+ (* -1 (((expt D 2) f) 'x) (g 'x))
-	        (* -1 (g 'x) ((D f) 'x))
-	        (* -1 ((D f) 'x) ((D g) 'x))
-	        (* -1 ((D g) 'x) (f 'x))
-	        (((expt D 2) f) 'x)
-	        (((expt D 3) f) 'x)))))
-  (comment testing "that basic arithmetic operations work on multivariate literal functions"
-      (is (= (((+  D  D) ff) 'x 'y)
-             (down (* 2 (((partial 0) ff) 'x 'y)) (* 2 (((partial 1) ff) 'x 'y)))))
-      (is (= (((-  D  D) ff) 'x 'y)
-             (down 0 0)))
-      (is (= (((*  D  D) ff) 'x 'y)
-             (down
-               (down (((partial 0) ((partial 0) ff)) 'x 'y) (((partial 0) ((partial 1) ff)) 'x 'y))
-               (down (((partial 1) ((partial 0) ff)) 'x 'y) (((partial 1) ((partial 1) ff)) 'x 'y)))))
-      (is (= (((*  (partial 1)  (partial 0)) ff) 'x 'y)
-             (((partial 1) ((partial 0) ff)) 'x 'y)))))
-             
-    ;;; more testing to come as we implement multivariate literal functions that rely on operations on structures....             
-
-
-
-
-      
-
-=======
   (testing "that their arithmetic operations compose correctly, as per SICM -  'Our Notation'"
     (is (= (simplify (((* (+ D 1)(- D 1)) f) 'x))
            '(+ (((expt D 2) f) x) (* -1 (f x))) )))
@@ -105,4 +84,3 @@
            (((partial 1) ((partial 0) ff)) 'x 'y)))))
 
     ;;; more testing to come as we implement multivariate literal functions that rely on operations on structures....
->>>>>>> af2eb8e2458a7ebca8e63f8ebc9fd1fc35db07bb

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -41,10 +41,10 @@
             ))
 
 ; make private?            
-(def f (literal-function 'f))
-(def g (literal-function 'g))
-(def ff (literal-function 'ff [0 0] 0))
-(def gg (literal-function 'gg [0 0] 0))
+(def f ^:private (literal-function 'f))
+(def g ^:private (literal-function 'g))
+(def ff ^:private (literal-function 'ff [0 0] 0))
+(def gg ^:private (literal-function 'gg [0 0] 0))
 
 
 ;; Test operations with Operators
@@ -55,11 +55,13 @@
     )
   (testing "that they compose with other Operators"
     (is (every? operator? [(* D D)(* D (partial 0))(*(partial 0) D)(* (partial 0)(partial 1))])))
+        
   (testing "that multiplication of Operators is equivalent to application/composition"           
-     (is (= (((* D D) ff) 'x 'y) 
-            ((D (D ff))'x 'y)))
-     (is (= (((* (partial 0)(partial 1)) ff)'x 'y) 
-            (((partial 0) ((partial 1) ff))'x 'y))))
+     (is (= (((* D D) ff) 'x 'y)
+	    ((D (D ff)) 'x 'y)))
+     (is (= (((* (partial 0)(partial 1)) ff) 'x 'y)
+            (((partial 0) ((partial 1) ff)) 'x 'y))))
+            
   (testing "that their arithmetic operations compose correctly, as per SICM -  'Our Notation'"
     (is (= (simplify (((* (+ D 1)(- D 1)) f) 'x))
            '(+ (((expt D 2) f) x) (* -1 (f x))) )))
@@ -71,16 +73,18 @@
                (* -1 ((D g) x) (f x))
                (((expt D 2) f) x)
                (((expt D 3) f) x)))))
+
   (testing "that basic arithmetic operations work on multivariate literal functions"
     (is (= (simplify (((+  D  D) ff) 'x 'y))
            '(down (* 2 (((∂ 0) ff) x y)) (* 2 (((∂ 1) ff) x y)))))
     (is (= (simplify (((-  D  D) ff) 'x 'y))
-           '(down 0 0)))
+           '(down 0 0)))         
     (is (= (((*  D  D) ff) 'x 'y)
            (down
             (down (((partial 0) ((partial 0) ff)) 'x 'y) (((partial 0) ((partial 1) ff)) 'x 'y))
             (down (((partial 1) ((partial 0) ff)) 'x 'y) (((partial 1) ((partial 1) ff)) 'x 'y)))))
     (is (= (((*  (partial 1)  (partial 0)) ff) 'x 'y)
            (((partial 1) ((partial 0) ff)) 'x 'y)))))
-
+           
+           
     ;;; more testing to come as we implement multivariate literal functions that rely on operations on structures....

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -23,10 +23,10 @@
             [sicmutils.operator :refer :all]
             ))
 
-(def f (literal-function 'f))
-(def g (literal-function 'g))
-(def ff (literal-function 'ff [0 0] 0))
-(def gg (literal-function 'gg [0 0] 0))
+(def ^:private f (literal-function 'f))
+(def ^:private g (literal-function 'g))
+(def ^:private ff (literal-function 'ff [0 0] 0))
+(def ^:private gg (literal-function 'gg [0 0] 0))
 
             
 ;; Test operations with Operators            
@@ -37,9 +37,21 @@
     )
   (testing "that they compose with other Operators"
     (is (every? operator? [(* D D)(* D (partial 0))(*(partial 0) D)(* (partial 0)(partial 1))])))
+
+;; not run through Travis yet    
+    
+  (testing "that multiplication of Operators is equivalent to application/composition"           
+     (is (= (((* D D) ff) 'x 'y) 
+            ((D (D ff))'x 'y)))
+     (is (= (((* (partial 0)(partial 1)) ff)'x 'y) 
+            (((partial 0) ((partial 1) ff))'x 'y))))
+            
+;; ---------------------            
+
   (comment testing "that their arithmetic operations compose correctly, as per SICM -  'Our Notation'"
       (is (= (((* (+ D 1)(- D 1)) f) 'x) 
-             (+ (((expt D 2) f) 'x) (* -1 (f 'x))) )))
+             (+ (((expt D 2) f) 'x) (* -1 (f 'x))))))
+
   (comment testing "that Operators compose correctly with functions"
       (is (= ((D ((* (- D g)(+ D 1)) f)) 'x)
 	     (+ (* -1 (((expt D 2) f) 'x) (g 'x))

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -84,7 +84,53 @@
             (down (((partial 0) ((partial 0) ff)) 'x 'y) (((partial 0) ((partial 1) ff)) 'x 'y))
             (down (((partial 1) ((partial 0) ff)) 'x 'y) (((partial 1) ((partial 1) ff)) 'x 'y)))))
     (is (= (((*  (partial 1)  (partial 0)) ff) 'x 'y)
-           (((partial 1) ((partial 0) ff)) 'x 'y)))))
+           (((partial 1) ((partial 0) ff)) 'x 'y))))
+           
+  (testing "negation of Operator"
+    (is (= (((* (- (- D))) ff) 'x 'y)  (((* (- (- D))) ff) 'x 'y))))
+
+  (testing "Addition of Operator and Structure (for multivariate literal-functions)"
+    (is (= (((+ (expt D 2) D 1) ff) 1 2)
+           (down
+             (down
+               (+ (((∂ 0) ((∂ 0) ff)) 1 2) (((∂ 0) ff) 1 2) (ff 1 2))
+               (+ (((∂ 0) ((∂ 1) ff)) 1 2) (((∂ 0) ff) 1 2) (ff 1 2)))
+             (down
+               (+ (((∂ 1) ((∂ 0) ff)) 1 2) (((∂ 1) ff) 1 2) (ff 1 2))
+               (+ (((∂ 1) ((∂ 1) ff)) 1 2) (((∂ 1) ff) 1 2) (ff 1 2))))))
+    (is (= (let [grfn (fn [x y] (+ (* x x)(* 3 y)))]  ;; test against a real function
+              (((+ (expt D 2) D 1) grfn) 1 2))
+           (down (down 11 9) 10))))
+    
+  (testing "Subtraction of Operator and Structure (for multivariate literal-functions)"
+    (is (= (simplify (((- (expt D 2) D) ff) 1 2))
+           '(down
+              (down
+                (+ (((∂ 0) ((∂ 0) ff)) 1 2) (* -1 (((∂ 0) ff) 1 2)))
+                (+ (((∂ 0) ((∂ 1) ff)) 1 2) (* -1 (((∂ 0) ff) 1 2))))
+              (down
+                (+ (((∂ 1) ((∂ 0) ff)) 1 2) (* -1 (((∂ 1) ff) 1 2)))
+                (+ (((∂ 1) ((∂ 1) ff)) 1 2) (* -1 (((∂ 1) ff) 1 2)))))))
+    (is (= (let [grfn (fn [x y] (+ (* x x)(* 3 y)))]  ;; test against a real function
+              (((- (expt D 2) D) grfn) 1 2))
+           (down (down 0 -2) -3))))
+        
+  (testing "Addition of Differential and Structure (for multivariate literal-functions)"
+    (is (= (simplify (((* (+ D 3)(+ D 2)) ff) 1 2))
+           (simplify (((+ (expt D 2) (* 5 D) 6) ff) 1 2)))
+           ))
+    
+  (testing "Subtraction of Differential to Structure (for multivariate literal-functions)"
+    (is (= (simplify (((* (+ D 1)(- D 1)) ff) 'x 'y))
+           (simplify (((+ (expt D 2) -1) ff) 'x 'y)))
+           )
+    (is (= (simplify (((* (+ D 3)(- D 2)) ff) 1 2))
+           (simplify (((+ (expt D 2) D -6) ff) 1 2)))
+           )
+    (is (= (let [grfn (fn [x y] (+ (* x x)(* 3 y)))]  ;; test against a real function
+              (((* (+ D 3)(- D 2)) grfn) 1 2))
+           (down (down -38 -40) (down -39 -39))))
+           )
+           )
            
            
-    ;;; more testing to come as we implement multivariate literal functions that rely on operations on structures....

--- a/test/sicmutils/operator_test.clj
+++ b/test/sicmutils/operator_test.clj
@@ -87,7 +87,7 @@
            (((partial 1) ((partial 0) ff)) 'x 'y))))
            
   (testing "negation of Operator"
-    (is (= (((* (- (- D))) ff) 'x 'y)  (( D ff) 'x 'y))))
+    (is (= (simplify (((* (- (- D))) ff) 'x 'y))  (simplify (( D ff) 'x 'y)))))
 
   (testing "Addition of Operator and Structure (for multivariate literal-functions)"
     (is (= (((+ (expt D 2) D 1) ff) 1 2)


### PR DESCRIPTION
I have also added an s/map-struct to sicmutils.structure, to allow the application of the operations on the structures.  We may want to review it later.  Basically it's meant to correspond - approximately - to MIT-Sheme / scmutils vector-map (although that one won't work on down vectors):
```
 > (vector-map square (up 2 3 4))
#|
(up 4 9 16)
|#
```
Unit tests indicate all working as they should be
