### PR TITLE
Attempt at adding Cloverage with codecov support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ cache:
 script:
   - lein test
   - lein test-cljs
+after_success:
+  - CLOVERAGE_VERSION=1.1.2 lein cloverage --codecov
+  - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,11 @@
   :profiles {:uberjar {:aot :all}
              :travis {:jvm-opts ["-Xmx512M"]}
              :dev {:plugins [~cljsbuild
+                             [lein-cloverage "1.1.2"]
                              [lein-doo "0.1.11"]]
+                   :cloverage {:ns-exclude-regex [#"sicmutils.rules"
+                                                  #"sicmutils.simplify"
+                                                  #"sicmutils.calculus.manifold"]}
                    :repl-options {:nrepl-middleware
                                   [cider.piggieback/wrap-cljs-repl]}
                    :dependencies [[org.clojure/test.check "0.9.0"]

--- a/src/sicmutils/generic.clj
+++ b/src/sicmutils/generic.clj
@@ -49,7 +49,7 @@
       (v/numerical? x)))
 
 (defmacro ^:private def-generic-function
-  "Defines a mutlifn using the provided symbol. Arranges for the multifn
+  "Defines a multifn using the provided symbol. Arranges for the multifn
   to answer the :arity message, reporting either [:exactly a] or
   [:between a b], according to the arguments given."
   [f a & b]


### PR DESCRIPTION
This PR attempts to add https://github.com/cloverage/cloverage, to generate a Coverage report for `codecov.io`. I think that the macros in the project may be too difficult for cloverage to handle; many tests fail with cloverage's instrumentation attached, and a few of the namespaces completely fail to be instrumented.

I wanted to push this anyway as an example of how to set this up. Feel free to close; at least we'll have it around, and if we want this, and I get some time, I can submit the specific errors as bugs to cloverage.

