### PR TITLE
Convert sicmutils.{expressions, generic}

### DIFF
--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -52,7 +52,7 @@
   [expr]
   (cond (instance? Expression expr) (:expression expr)
         (symbol? expr) expr
-        :else (throw (IllegalArgumentException. (str "unknown expression type:" expr)))))
+        :else (v/illegal (str "unknown expression type:" expr))))
 
 (defn variables-in
   "Return the 'variables' (e.g. symbols) found in the expression x,

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -41,12 +41,18 @@
 (defn fmap
   "Applies f to the expression part of e and creates from that an Expression otherwise like e."
   [f e]
-  (->> e :expression f (->Expression (:type e))))
+  (->Expression (:type e)
+                (f (:expression e))))
 
 (defn abstract? [^Expression x]
   ;; TODO: GJS also allows for up, down, matrix here. We do not yet have
   ;; abstract structures.
   (= (:type x) ::numerical-expression))
+
+(defn expression?
+  "Returns true if the argument is an expression, false otherwise."
+  [x]
+  (instance? Expression x))
 
 (defn expression-of
   [expr]

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -1,36 +1,36 @@
-;
-; Copyright © 2017 Colin Smith.
-; This work is based on the Scmutils system of MIT/GNU Scheme:
-; Copyright © 2002 Massachusetts Institute of Technology
-;
-; This is free software;  you can redistribute it and/or modify
-; it under the terms of the GNU General Public License as published by
-; the Free Software Foundation; either version 3 of the License, or (at
-; your option) any later version.
-;
-; This software is distributed in the hope that it will be useful, but
-; WITHOUT ANY WARRANTY; without even the implied warranty of
-; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-; General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License
-; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
 
 (ns sicmutils.generic
-  (:refer-clojure :rename {/ core-div}
-                  :exclude [+ - *])
-  (:require [sicmutils
-             [value :as v]
-             [expression :as x]])
-  (:import [sicmutils.expression Expression]
-           (clojure.lang Keyword)))
+  (:refer-clojure :rename {/ core-div
+                           + core-plus
+                           - core-minus
+                           * core-times}
+                  #?@(:cljs [:exclude [/ + - * divide]]))
+  (:require [sicmutils.value :as v]
+            [sicmutils.expression :as x])
+  #?(:cljs (:require-macros [sicmutils.generic :refer [def-generic-function]])))
 
 ;;; classifiers
 
 (defn literal-number?
   [x]
-
   (= (:type x) ::x/numerical-expression))
 
 (defn abstract-number?
@@ -39,7 +39,7 @@
 
 (defn abstract-quantity?
   [x]
-  (and (instance? Expression x)
+  (and (x/expression? x)
        (x/abstract? x)))
 
 (defn numerical-quantity?
@@ -48,16 +48,29 @@
       (abstract-number? x)
       (v/numerical? x)))
 
+(defmacro ^:private fork
+  "I borrowed this lovely, mysterious macro from `macrovich`:
+  https://github.com/cgrand/macrovich. This allows us to fork behavior inside of
+  a macro at macroexpansion time, not at read time."
+  [& {:keys [cljs clj]}]
+  (if (contains? &env '&env)
+    `(if (:ns ~'&env) ~cljs ~clj)
+    (if #?(:clj (:ns &env) :cljs true)
+      cljs
+      clj)))
+
 (defmacro ^:private def-generic-function
   "Defines a multifn using the provided symbol. Arranges for the multifn
   to answer the :arity message, reporting either [:exactly a] or
   [:between a b], according to the arguments given."
   [f a & b]
   (let [arity (if b `[:between ~a ~@b] [:exactly a])
-        docstring (str "generic " f)]
+        docstring (str "generic " f)
+        klass (fork :clj clojure.lang.Keyword :cljs 'cljs.core/Keyword)]
     `(do
        (defmulti ~f ~docstring v/argument-kind)
-       (defmethod ~f [Keyword] [k#] ({:arity ~arity :name '~f} k#)))))
+       (defmethod ~f [~klass] [k#]
+         ({:arity ~arity :name '~f} k#)))))
 
 (def-generic-function add 2)
 (def-generic-function mul 2)
@@ -97,7 +110,7 @@
 (defmulti simplify v/argument-kind)
 
 (defn ^:private bin+ [a b]
-  (cond (and (number? a) (number? b)) (+' a b)
+  (cond (and (number? a) (number? b)) (#?(:clj +' :cljs core-plus) a b)
         (v/nullity? a) b
         (v/nullity? b) a
         :else (add a b)))
@@ -106,7 +119,7 @@
   (reduce bin+ 0 args))
 
 (defn ^:private bin- [a b]
-  (cond (and (number? a) (number? b)) (-' a b)
+  (cond (and (number? a) (number? b)) (#?(:clj -' :cljs core-minus) a b)
         (v/nullity? b) a
         (v/nullity? a) (negate b)
         :else (sub a b)))
@@ -117,7 +130,7 @@
         :else (bin- (first args) (reduce bin+ (next args)))))
 
 (defn ^:private bin* [a b]
-  (cond (and (number? a) (number? b)) (*' a b)
+  (cond (and (number? a) (number? b)) (#?(:clj *' :cljs core-times) a b)
         (and (number? a) (v/nullity? a)) (v/zero-like b)
         (and (number? b) (v/nullity? b)) (v/zero-like a)
         (v/unity? a) b

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -28,7 +28,12 @@
     (is (= '#{x} (e/variables-in 'x)))
     )
   (testing "walk"
-    (is (= 12 (e/walk-expression '(+ 3 4 x) {'x 5} {'+ +} )))
+    (is (= 12 (e/walk-expression '(+ 3 4 x) {'x 5} {'+ +})))
     (is (= 0 (e/walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'* * '+ +})))
     (is (thrown? #?(:clj Exception :cljs js/Error)
                  (e/walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'+ +})))))
+
+(deftest is-expression
+  (is (e/expression?
+       (->> (e/literal-number '(* 4 3)))))
+  (is (not (e/expression? "face"))))

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -18,20 +18,17 @@
 ;
 
 (ns sicmutils.expression-test
-  (:require [clojure.test :refer :all]
-            [sicmutils.expression :refer :all]))
+  (:require #?(:clj  [clojure.test :refer :all]
+               :cljs [cljs.test :as t :refer-macros [is deftest testing]])
+            [sicmutils.expression :as e]))
 
 (deftest expressions
   (testing "variables-in"
-    (is (= '#{a b c d x y * +} (variables-in '(+ x (* 3 y) [a [b 9 c] [3 4 5 d]]))))
-    (is (= '#{x} (variables-in 'x)))
+    (is (= '#{a b c d x y * +} (e/variables-in '(+ x (* 3 y) [a [b 9 c] [3 4 5 d]]))))
+    (is (= '#{x} (e/variables-in 'x)))
     )
   (testing "walk"
-    (is (= 12 (walk-expression '(+ 3 4 x) {'x 5} {'+ +} )))
-    (is (= 0 (walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'* * '+ +})))
-    (is (thrown? Exception
-                 (walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'+ +})))))
-
-(deftest foo
-  (testing "foo"
-    (is (= 1 1))))
+    (is (= 12 (e/walk-expression '(+ 3 4 x) {'x 5} {'+ +} )))
+    (is (= 0 (e/walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'* * '+ +})))
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (e/walk-expression '(+ 3 (* 4 y) x) {'x 5 'y -2} {'+ +})))))

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -19,10 +19,10 @@
 
 (ns sicmutils.generic-test
   (:refer-clojure :exclude [+ - * / zero?])
-  (:require [clojure.test :refer :all]
-            [sicmutils
-             [value :as v]
-             [generic :refer :all]]))
+  (:require #?(:clj  [clojure.test :refer :all]
+               :cljs [cljs.test :as t :refer-macros [is deftest testing]])
+            [sicmutils.value :as v]
+            [sicmutils.generic :as g]))
 
 (defmulti s* v/argument-kind)
 (defmulti s+ v/argument-kind)
@@ -35,10 +35,13 @@
   [s t]
   (apply str (for [cs s ct t] (str cs ct))))
 
-(defmethod s* [Number String] [n s] (multiply-string n s))
-(defmethod s* [String Number] [s n] (multiply-string n s))
-(defmethod s* [String String] [s t] (product-string s t))
-(defmethod s+ [String String] [s t] (str s t))
+(def number #?(:clj Number :cljs js/Number))
+(def string #?(:clj String :cljs js/String))
+
+(defmethod s* [number string] [n s] (multiply-string n s))
+(defmethod s* [string number] [s n] (multiply-string n s))
+(defmethod s* [string string] [s t] (product-string s t))
+(defmethod s+ [string string] [s t] (str s t))
 
 (deftest handler-fn
   (testing "multiply-string"
@@ -58,13 +61,13 @@
 
 (deftest generic-plus
   (testing "simple"
-    (is (= 0 (+)))
-    (is (= 7 (+ 7)))
-    (is (= 7 (+ 3 4))))
+    (is (= 0 (g/+)))
+    (is (= 7 (g/+ 7)))
+    (is (= 7 (g/+ 3 4))))
   (testing "many"
-    (is (= 33 (+ 3 4 5 6 7 8)))))
+    (is (= 33 (g/+ 3 4 5 6 7 8)))))
 
 (deftest type-assigner
   (testing "types"
-    (is (= Long (v/kind 9)))
-    (is (= Double (v/kind 99.0)))))
+    (is (= #?(:clj Long :cljs js/Number) (v/kind 9)))
+    (is (= #?(:clj Double :cljs js/Number) (v/kind 99.0)))))

--- a/test/sicmutils/runner.cljs
+++ b/test/sicmutils/runner.cljs
@@ -2,10 +2,12 @@
   (:require [doo.runner :refer-macros [doo-tests]]
             [pattern.match-test]
             [pattern.rule-test]
+            [sicmutils.expression-test]
             [sicmutils.rules-test]
             [sicmutils.value-test]))
 
 (doo-tests 'pattern.match-test
            'pattern.rule-test
+           'sicmutils.expression-test
            'sicmutils.rules-test
            'sicmutils.value-test)

--- a/test/sicmutils/runner.cljs
+++ b/test/sicmutils/runner.cljs
@@ -3,11 +3,13 @@
             [pattern.match-test]
             [pattern.rule-test]
             [sicmutils.expression-test]
+            [sicmutils.generic-test]
             [sicmutils.rules-test]
             [sicmutils.value-test]))
 
 (doo-tests 'pattern.match-test
            'pattern.rule-test
            'sicmutils.expression-test
+           'sicmutils.generic-test
            'sicmutils.rules-test
            'sicmutils.value-test)


### PR DESCRIPTION
This got tricky! Macros always have something to teach me. This time it was about how to generate the correct runtime behavior from within the compile-time-expanding macro.