### PR TITLE
Consolidate numeric types, pave the way for more "generic" generics

### DIFF
--- a/src/sicmutils/calculus/derivative.clj
+++ b/src/sicmutils/calculus/derivative.clj
@@ -42,6 +42,7 @@
   (nullity? [_] (every? v/nullity? (map coefficient terms)))
   (unity? [_] false)
   (zero-like [_] 0)
+  (one-like [_] 1)
   (freeze [_] `[~'Differential ~@terms])
   (exact? [_] false)
   (numerical? [d] (g/numerical-quantity? (differential-of d)))

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -58,7 +58,8 @@
   (zero-like [_] ZERO)
   (one-like [_] ONE)
   (freeze [c] (list 'complex (real-part c) (imag-part c)))
-  (exact? [_] false)
+  (exact? [c] (and (v/exact? (real-part c))
+                   (v/exact? (imag-part c))))
   (numerical? [_] true)
   (kind [_] ::complex))
 

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -18,11 +18,7 @@
 ;;
 
 (ns sicmutils.generic
-  (:refer-clojure :rename {/ core-div
-                           + core-plus
-                           - core-minus
-                           * core-times}
-                  #?@(:cljs [:exclude [/ + - * divide]]))
+  (:refer-clojure :exclude [/ + - * divide])
   (:require [sicmutils.value :as v]
             [sicmutils.expression :as x])
   #?(:cljs (:require-macros [sicmutils.generic :refer [def-generic-function]])))
@@ -44,8 +40,7 @@
 
 (defn numerical-quantity?
   [x]
-  (or (number? x)
-      (abstract-number? x)
+  (or (abstract-number? x)
       (v/numerical? x)))
 
 (defmacro ^:private fork
@@ -119,8 +114,7 @@
 (defmulti simplify v/argument-kind)
 
 (defn ^:private bin+ [a b]
-  (cond (and (number? a) (number? b)) (#?(:clj +' :cljs core-plus) a b)
-        (v/nullity? a) b
+  (cond (v/nullity? a) b
         (v/nullity? b) a
         :else (add a b)))
 
@@ -128,8 +122,7 @@
   (reduce bin+ 0 args))
 
 (defn ^:private bin- [a b]
-  (cond (and (number? a) (number? b)) (#?(:clj -' :cljs core-minus) a b)
-        (v/nullity? b) a
+  (cond (v/nullity? b) a
         (v/nullity? a) (negate b)
         :else (sub a b)))
 
@@ -139,9 +132,8 @@
         :else (bin- (first args) (reduce bin+ (next args)))))
 
 (defn ^:private bin* [a b]
-  (cond (and (number? a) (number? b)) (#?(:clj *' :cljs core-times) a b)
-        (and (number? a) (v/nullity? a)) (v/zero-like b)
-        (and (number? b) (v/nullity? b)) (v/zero-like a)
+  (cond (and (v/numerical? a) (v/nullity? a)) (v/zero-like b)
+        (and (v/numerical? b) (v/nullity? b)) (v/zero-like a)
         (v/unity? a) b
         (v/unity? b) a
         :else (mul a b)))
@@ -161,8 +153,7 @@
   (reduce bin* 1 args))
 
 (defn ^:private bin-div [a b]
-  (cond (and (number? a) (number? b)) (core-div a b)
-        (v/unity? b) a
+  (cond (v/unity? b) a
         :else (div a b)))
 
 (defn / [& args]

--- a/src/sicmutils/matrix.clj
+++ b/src/sicmutils/matrix.clj
@@ -31,6 +31,7 @@
 
 (deftype Matrix [r c ^PersistentVector v]
   v/Value
+  (numerical? [_] false)
   (nullity? [_] (every? #(every? v/nullity? %) v))
   (unity? [_] false)
   ;; TODO: zero-like and one-like should use a recursive copy to find the 0/1 elements

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -35,16 +35,7 @@
 
 #?(:cljs (def ^:private ratio? (constantly false)))
 
-(extend-type #?(:clj Number :cljs number)
-  v/Value
-  (nullity? [x] (core-zero? x))
-  (unity? [x] (== 1 x))
-  (zero-like [_] 0)
-  (one-like [_] 1)
-  (freeze [x] x)
-  (exact? [x] (or (integer? x) (ratio? x)))
-  (numerical? [_] true)
-  (kind [x] (type x)))
+
 
 (defn ^:private define-unary-operation
   [generic-operation core-operation]

--- a/src/sicmutils/operator.clj
+++ b/src/sicmutils/operator.clj
@@ -30,6 +30,7 @@
   v/Value
   (freeze [_] (v/freeze name))
   (kind [_] (:subtype context))
+  (numerical? [_] false)
   (nullity? [_] false)
   (unity? [_] false)
   IFn

--- a/src/sicmutils/polynomial.clj
+++ b/src/sicmutils/polynomial.clj
@@ -87,6 +87,7 @@
   v/Value
   (nullity? [_] (empty? xs->c))
   (numerical? [_] false)
+  (exact? [_] false)
   (zero-like [_] (Polynomial. arity empty-coefficients))
   (one-like [_] (make-constant arity (v/one-like (coefficient (exponents xs->c)))))
   (unity? [_] (and (= (count xs->c) 1)
@@ -107,7 +108,7 @@
       (str "("
            (clojure.string/join ";"
                                 (take n (for [[k v] xs->c]
-                                           (str v "*" (clojure.string/join "," k)))))
+                                          (str v "*" (clojure.string/join "," k)))))
            (if (> c n) (format " ...and %d more terms" (- c n)))
            ")"))))
 

--- a/src/sicmutils/rational_function.clj
+++ b/src/sicmutils/rational_function.clj
@@ -37,6 +37,7 @@
   v/Value
   (nullity? [_] (v/nullity? u))
   (unity? [_] (and (v/unity? u) (v/unity? v)))
+  (numerical? [_] false)
   (kind [_] ::rational-function)
   Object
   (equals [_ b]

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -36,7 +36,7 @@
   ;; Freezing an expression means removing wrappers and other metadata
   ;; from subexpressions, so that the result is basically a pure
   ;; S-expression with the same structure as the input. Doing this will
-  ;; rob an expression of useful information fur further computation; so
+  ;; rob an expression of useful information for further computation; so
   ;; this is intended to be done just before simplification and printing, to
   ;; simplify those processes.
   (freeze [this])
@@ -49,11 +49,28 @@
 #?(:cljs
    (def ^:private ratio? (constantly false)))
 
-(extend-type #?(:clj Object :cljs default)
-  Value
-  (nullity? [o] (and (number? o) (core-zero? o)))
+(extend-protocol Value
+  #?(:clj Number :cljs number)
+  (nullity? [x] (core-zero? x))
+  (unity? [x] (== 1 x))
+  (zero-like [_] 0)
+  (one-like [_] 1)
+  (freeze [x] x)
+  (exact? [x] (or (integer? x) (ratio? x)))
+  (numerical? [_] true)
+  (kind [x] (type x))
+
+  nil
+  (freeze [_] nil)
   (numerical? [_] false)
-  (unity? [o] (and (number? o) (== o 1)))
+  (nullity? [_] true)
+  (unity?[_] false)
+  (kind [_] nil)
+
+  #?(:clj Object :cljs default)
+  (nullity? [o] false)
+  (numerical? [_] false)
+  (unity? [o] false)
   (exact? [o] (or (integer? o) (ratio? o)))
   (zero-like [o] (cond (number? o) 0
                        (instance? Symbol o) 0
@@ -75,12 +92,6 @@
                           (@object-name-map o)
                           o)))
   (kind [o] (primitive-kind o)))
-
-(extend-type nil
-  Value
-  (freeze [_] nil)
-  (numerical? [_] nil)
-  (kind [_] nil))
 
 (defn add-object-symbols!
   [o->syms]

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -71,18 +71,15 @@
   (nullity? [o] false)
   (numerical? [_] false)
   (unity? [o] false)
-  (exact? [o] (or (integer? o) (ratio? o)))
-  (zero-like [o] (cond (number? o) 0
-                       (instance? Symbol o) 0
+  (exact? [o] false)
+  (zero-like [o] (cond (instance? Symbol o) 0
                        (or (fn? o) (instance? MultiFn o)) (with-meta
                                                             (constantly 0)
                                                             {:arity (arity o)
                                                              :from :object-zero-like})
 
                        :else (u/unsupported (str "zero-like: " o))))
-  (one-like [o] (if (number? o)
-                  1
-                  (u/unsupported (str "one-like: " o))))
+  (one-like [o] (u/unsupported (str "one-like: " o)))
   (freeze [o] (cond
                 (vector? o) (mapv freeze o)
                 (sequential? o) (map freeze o)

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -46,8 +46,18 @@
 
     (is (= '(complex 10.0 0.0) (v/freeze (c/complex 10))))
     (is (v/numerical? (c/complex 10)))
-    (is (not (v/exact? (c/complex 10))))
-    (is (not (v/exact? (c/complex 0 10.1))))))
+
+    (testing "exact?"
+      (is (not (v/exact? (c/complex 0 10.1))))
+
+      ;; cljs is able to maintain exact numbers here.
+      #?@(:clj
+          [(is (not (v/exact? (c/complex 10))))
+           (is (not (v/exact? (c/complex 10 12))))]
+
+          :cljs
+          [(is (v/exact? (c/complex 10)))
+           (is (v/exact? (c/complex 10 12)))]))))
 
 (let [i (c/complex 0 1)
       pi Math/PI]

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -59,59 +59,29 @@
     (is (= "zzz" (s+ "" "zzz")))
     ))
 
-(deftest generic-plus
-  (testing "simple"
-    (is (= 7 (g/+ 3 4)))
-    (is (= 4 (g/+ 2 2)))
-    (is (= 3.5 (g/+ 1.5 2))))
-
-  (testing "many"
-    (is (= 0 (g/+)))
-    (is (= 3.14 (g/+ 3.14)))
-    (is (= 7 (g/+ 7)))
-    (is (= 10 (g/+ 1 2 3 4)))
-    (is (= 33 (g/+ 3 4 5 6 7 8)))))
-
-(deftest generic-minus
-  "Subtraction with a single arg doesn't work since we currently lack a default
-  implementation for negate."
-  (testing "simple"
-    (is (= 2.14 (g/- 3.14 1))))
-
-  (testing "many"
-    (is (= 0 (g/-)))
-    (is (= -14 (g/- 10 9 8 7)))))
-
-(deftest generic-times
-  (testing "simple"
-    (is (= 20 (g/* 5 4))))
-
-  (testing "many"
-    (is (= 1 (g/*)))
-    (is (= 2 (g/* 2)))
-    (is (= 4 (g/* 2 2)))
-    (is (= 8 (g/* 2 2 2)))))
-
-(deftest generic-divide
-  "division with a single argument doesn't work, since there's currently no
-  default implementation for invert."
-  (testing "simple"
-    (is (= 5 (g/divide 20 4))))
-
-  (testing "many"
-    (is (= 1 (g/divide)))
-    (is (= 2 (g/divide 8 2 2)))))
-
-#?(:clj
-   (deftest with-ratios
-     (is (= 13/40 (g/+ 1/5 1/8)))
-     (is (= 1/8 (g/- 3/8 1/4)))
-     (is (= 5/4 (g/divide 5 4)))
-     (is (= 1/2 (g/divide 1 2)))
-     (is (= 1/4 (g/divide 1 2 2)))
-     (is (= 1/8 (g/divide 1 2 2 2)))))
-
 (deftest type-assigner
   (testing "types"
     (is (= #?(:clj Long :cljs js/Number) (v/kind 9)))
     (is (= #?(:clj Double :cljs js/Number) (v/kind 99.0)))))
+
+(deftest generic-plus
+  (is (= 0 (g/+)) "no args returns additive identity")
+  (is (= 3.14 (g/+ 3.14)) "single arg should return itself")
+  (is (= 10 (g/+ 0 10 0.0 0 0)) "multi-arg works, as long as zeros appear.")
+  (is (= "happy" (g/+ 0 "happy" 0.0 0 0)) "returns really anything."))
+
+(deftest generic-minus
+  (is (= 0 (g/-)) "no-arity returns the additive identity.")
+  (is (= 10 (g/- 10 0)) "Subtracting a zero works, with no implementations registered.")
+  (is (= "face" (g/- "face" 0))))
+
+(deftest generic-times
+  (is (= 1 (g/*)) "No args returns the multiplicative identity.")
+  (is (= 2 (g/* 2)) "single arg returns itself.")
+  (is (= 5 (g/* 5 1) (g/* 1 5)) "Anything times a 1 returns itself.")
+  (is (= "face" (g/* "face" 1) (g/* 1 "face")) "works for really anything."))
+
+(deftest generic-divide
+  (is (= 1 (g/divide)) "division with no args returns multiplicative identity")
+  (is (= 20 (g/divide 20 1)) "dividing by one a single time returns the input")
+  (is (= "face" (g/divide "face" 1 1 1 1.0 1)) "dividing by 1 returns the input"))

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -28,30 +28,6 @@
 
 (def near (v/within 1e-12))
 
-(deftest value-protocol
-  ;; These really want to be generative tests.
-  ;;
-  ;; TODO convert, once we sort out the cljs test.check story.
-  (is (v/nullity? 0))
-  (is (v/nullity? 0.0))
-  (is (not (v/nullity? 1)))
-  (is (not (v/nullity? 1.0)))
-  (is (v/nullity? (v/zero-like 100)))
-  (is (= 0 (v/zero-like 2)))
-  (is (= 0 (v/zero-like 3.14)))
-
-  (is (v/unity? 1))
-  (is (v/unity? 1.0))
-  (is (v/unity? (v/one-like 100)))
-  (is (not (v/unity? 2)))
-  (is (not (v/unity? 0.0)))
-
-  (is (= 10 (v/freeze 10)))
-  (is (v/numerical? 10))
-  (is (isa? (v/kind 10) u/numtype))
-  (is (v/exact? 10))
-  (is (not (v/exact? 10.1))))
-
 (deftest arithmetic
   #?(:clj
      (testing "with-ratios"
@@ -163,3 +139,45 @@
     (is (= 1 (g/remainder 5N 2)))
     (is (= 1 (g/remainder 5 2N)))
     (is (= 1 (g/remainder 5N 2N)))))
+
+;; Test of generic wrapper operations.
+
+(deftest generic-plus
+  "sicmutils.numbers provides implementations of the methods needed by g/+. Test
+  that these functions now come work with numbers."
+  (testing "simple"
+    (is (= 7 (g/+ 3 4)))
+    (is (= 4 (g/+ 2 2)))
+    (is (= 3.5 (g/+ 1.5 2))))
+
+  (testing "many"
+    (is (= 10 (g/+ 1 2 3 4)))
+    (is (= 33 (g/+ 3 4 5 6 7 8)))))
+
+(deftest generic-minus
+  "numbers provides implementations, so test behaviors."
+  (is (= -3.14 (g/- 3.14)))
+  (is (= 2.14 (g/- 3.14 1)))
+
+  (testing "many"
+    (is (= -14 (g/- 10 9 8 7)))))
+
+(deftest generic-times
+  "numbers provides implementations, so test behaviors."
+  (is (= 20 (g/* 5 4)))
+  (is (= 4 (g/* 2 2)))
+  (is (= 8 (g/* 2 2 2))))
+
+(deftest generic-divide
+  "numbers provides implementations, so test behaviors."
+  (is (= 5 (g/divide 20 4)))
+  (is (= 2 (g/divide 8 2 2))))
+
+#?(:clj
+   (deftest with-ratios
+     (is (= 13/40 (g/+ 1/5 1/8)))
+     (is (= 1/8 (g/- 3/8 1/4)))
+     (is (= 5/4 (g/divide 5 4)))
+     (is (= 1/2 (g/divide 1 2)))
+     (is (= 1/4 (g/divide 1 2 2)))
+     (is (= 1/8 (g/divide 1 2 2 2)))))

--- a/test/sicmutils/value_test.cljc
+++ b/test/sicmutils/value_test.cljc
@@ -20,9 +20,34 @@
 (ns sicmutils.value-test
   (:require #?(:clj  [clojure.test :refer :all]
                :cljs [cljs.test :as t :refer-macros [is deftest]])
+            [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
      (:import (clojure.lang PersistentVector))))
+
+(deftest value-protocol-numbers
+  ;; These really want to be generative tests.
+  ;;
+  ;; TODO convert, once we sort out the cljs test.check story.
+  (is (v/nullity? 0))
+  (is (v/nullity? 0.0))
+  (is (not (v/nullity? 1)))
+  (is (not (v/nullity? 1.0)))
+  (is (v/nullity? (v/zero-like 100)))
+  (is (= 0 (v/zero-like 2)))
+  (is (= 0 (v/zero-like 3.14)))
+
+  (is (v/unity? 1))
+  (is (v/unity? 1.0))
+  (is (v/unity? (v/one-like 100)))
+  (is (not (v/unity? 2)))
+  (is (not (v/unity? 0.0)))
+
+  (is (= 10 (v/freeze 10)))
+  (is (v/numerical? 10))
+  (is (isa? (v/kind 10) u/numtype))
+  (is (v/exact? 10))
+  (is (not (v/exact? 10.1))))
 
 #?(:cljs
    (deftest exposed-arities-test


### PR DESCRIPTION
This PR:

- adds a few (but not all) missing protocol methods to various types around the codebase
- moves the `v/Value` implementation for numbers into `value` itself, so no import's required to get this working
- modifies the `generic.{+, -, /, *} so they don't use `number?` anymore.

This lets the protocol do its work for allowing us to make the code more generic. Ratios and BigDecimal, etc won't return `true` for `number?` in Clojurescript. Complex numbers won't respond in Java, come to think of it. But these types implement `nullity?` and `unity?`, so we should totally be able to use these higher level generic functions and get some nice value out of them.