### PR TITLE
extract symbolic trig functions [hold]

### DIFF
--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -34,6 +34,10 @@
   (freeze [_] (v/freeze expression))
   (kind [_] type))
 
+(defn literal-number?
+  [x]
+  (= (:type x) ::numerical-expression))
+
 (defn literal-number
   [expression]
   (if (number? expression)

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -25,13 +25,10 @@
 
 ;;; classifiers
 
-(defn literal-number?
-  [x]
-  (= (:type x) ::x/numerical-expression))
-
 (defn abstract-number?
   [x]
-  (or (symbol? x) (literal-number? x)))
+  (or (symbol? x)
+      (x/literal-number? x)))
 
 (defn abstract-quantity?
   [x]


### PR DESCRIPTION
This PR extracts `g/sin`, `g/cos` and `g/tan` from the larger functions in `numsymb` into their own multimethod implementations.

I kept a branch in the existing functions, since some of the simplifier code is able to get access to those implementations directly via the `symbolic-operator` 

I'm submitting this because I think we're going to have to make the simplifications in `sin`, `cos` and `tan`, under the `number?` branch, apply more generally than `number?`.

In Clojurescript, Ratios and BigDecimal are not going to respond `true?` here, so there is probably some other predicate.

I am inching toward a world where everyone can implement very simple methods like `Math/sin`, and we can apply these simplifications more generally on top.