### PR TITLE
Add `deterministic?` option to force consistent ->Javascript ordering

### DIFF
--- a/src/sicmutils/infix.cljc
+++ b/src/sicmutils/infix.cljc
@@ -345,9 +345,10 @@
                               'exp "Math.exp"}
            :special-handlers {'up make-js-vector
                               'down make-js-vector})]
-    (fn [x & {:keys [symbol-generator parameter-order]
+    (fn [x & {:keys [symbol-generator parameter-order deterministic?]
              :or {symbol-generator (make-symbol-generator "_")
-                  parameter-order sort}}]
+                  parameter-order sort
+                  deterministic? true}}]
       (let [params (set/difference (x/variables-in x) operators-known)
             ordered-params (if (fn? parameter-order)
                              (parameter-order params)
@@ -367,4 +368,5 @@
                (print ";\n"))
              (print "  return ")
              (print (R new-expression))
-             (print ";\n}"))))))))
+             (print ";\n}"))
+           :deterministic? deterministic?))))))

--- a/src/sicmutils/infix.cljc
+++ b/src/sicmutils/infix.cljc
@@ -316,16 +316,21 @@
 (def ->JavaScript
   "Convert the given (simplified) expression to a JavaScript function.
   Parameters to the function will be extracted from the symbols in the
-  expression. Common subexpression elimination will be performed and
-  auxiliary variables will be bound in the body of the function; the
-  names of these symbols are obtained from the nullary function
-  option :symbol-generator, which defaults to a function yielding `_1,
-  ...`. If `:parameter-order is specified, it is used to determine
-  function parameter order in one of two ways: if it is set to a
-  function, that function will be called on the sequence of parameters
-  and is expected to return the parameters in the desired
-  sequence. Otherwise, it is interpreted as the sequence of parameters
-  itself. If not specified, the default behavior is `sort`."
+  expression. Common subexpression elimination will be performed and auxiliary
+  variables will be bound in the body of the function; the names of these
+  symbols are obtained from the nullary function option :symbol-generator, which
+  defaults to a function yielding `_1, ...`. If `:parameter-order is specified,
+  it is used to determine function parameter order in one of two ways: if it is
+  set to a function, that function will be called on the sequence of parameters
+  and is expected to return the parameters in the desired sequence. Otherwise,
+  it is interpreted as the sequence of parameters itself. If not specified, the
+  default behavior is `sort`.
+
+  If `:deterministic? true` is supplied, the function will assign variables by
+  sorting the string representations of each term before assignment. Otherwise,
+  the nondeterministic order of hash maps inside this function won't guarantee a
+  consistent variable naming convention in the returned function. For tests, set
+  `:deterministic? true`."
   (let [operators-known '#{sin cos tan asin acos atan sqrt abs pow + - * /
                            expt exp log up down}
         make-js-vector #(str \[ (s/join ", " %) \])
@@ -347,8 +352,7 @@
                               'down make-js-vector})]
     (fn [x & {:keys [symbol-generator parameter-order deterministic?]
              :or {symbol-generator (make-symbol-generator "_")
-                  parameter-order sort
-                  deterministic? true}}]
+                  parameter-order sort}}]
       (let [params (set/difference (x/variables-in x) operators-known)
             ordered-params (if (fn? parameter-order)
                              (parameter-order params)

--- a/src/sicmutils/numerical/compile.cljc
+++ b/src/sicmutils/numerical/compile.cljc
@@ -76,26 +76,28 @@
   by new variables (delivered by the supplied generator) and a seq
   of pairs of [aux variable, subexpression] used to reconstitute the
   value."
-  [expression symbol-generator continue]
-  (loop [x expression
-         expr-to-var {}]
-    (let [cs (atom {})
-          increment (fnil inc 0)]
-      ;; cs maps subexpressions to the number of times we have seen the
-      ;; expression.
-      (w/postwalk (fn [e]
-                    (when (and (seq? e) (not (expr-to-var e)))
-                      (swap! cs update e increment))
-                    e)
-                  x)
-
-      (let [new-syms (into {} (for [[k v] @cs :when (> v 1)] [k (symbol-generator)]))]
-        (if (empty? new-syms)
-          (discard-unreferenced-variables x
-                                          (into {} (for [[expr var] expr-to-var] [var expr]))
-                                          continue)
-          (let [joint-syms (into expr-to-var new-syms)]
-            (recur (w/postwalk-replace joint-syms x) joint-syms)))))))
+  [expression symbol-generator continue & {:keys [deterministic?]}]
+  (let [pairs (if deterministic?
+                (partial sort-by (comp str vec first))
+                identity)]
+    (loop [x expression
+           expr-to-var {}]
+      (let [cs (atom {})
+            increment (fnil inc 0)]
+        ;; cs maps subexpressions to the number of times we have seen the
+        ;; expression.
+        (w/postwalk (fn [e]
+                      (when (and (seq? e) (not (expr-to-var e)))
+                        (swap! cs update e increment))
+                      e)
+                    x)
+        (let [new-syms (into {} (for [[k v] (pairs @cs) :when (> v 1)] [k (symbol-generator)]))]
+          (if (empty? new-syms)
+            (discard-unreferenced-variables x
+                                            (into {} (for [[expr var] expr-to-var] [var expr]))
+                                            continue)
+            (let [joint-syms (into expr-to-var new-syms)]
+              (recur (w/postwalk-replace joint-syms x) joint-syms))))))))
 
 (defn ^:private initialize-cs-variables
   "Given a list of pairs of (symbol, expression) construct a
@@ -110,17 +112,18 @@
   dummy variables generated for the purpose of holding these values;
   the body of the let statement will be x with the subexpressions
   replaced by the dummy variables."
-  [x & {:keys [symbol-generator]
+  [x & {:keys [symbol-generator deterministic?]
         :or {symbol-generator gensym}}]
   (extract-common-subexpressions
-    x
-    symbol-generator
-    (fn [new-expression new-vars]
-      (if (> (count new-vars) 0)
-        (do
-          (log/info (format "common subexpression elimination: %d expressions" (count new-vars)))
-          `(let ~(initialize-cs-variables new-vars) ~new-expression))
-        new-expression))))
+   x
+   symbol-generator
+   (fn [new-expression new-vars]
+     (if (> (count new-vars) 0)
+       (do
+         (log/info (format "common subexpression elimination: %d expressions" (count new-vars)))
+         `(let ~(initialize-cs-variables new-vars) ~new-expression))
+       new-expression))
+   :deterministic? deterministic?))
 
 (defn ^:private compile-state-function2
   [f parameters initial-state]

--- a/test/sicmutils/examples/double_pendulum_test.clj
+++ b/test/sicmutils/examples/double_pendulum_test.clj
@@ -85,7 +85,9 @@
                 "  var _0011 = Math.pow(_0010, 2);\n"
                 "  return [1, [thetadot, phidot], [(- l1 * m2 * _0006 * _0010 * _000e - l2 * m2 * _0005 * _0010 + g * m2 * _000e * _0008 - g * m1 * _0009 - g * m2 * _0009) / (l1 * m2 * _0011 + l1 * m1), (l2 * m2 * _0005 * _0010 * _000e + l1 * m1 * _0006 * _0010 + l1 * m2 * _0006 * _0010 + g * m1 * _0009 * _000e + g * m2 * _0009 * _000e - g * m1 * _0008 - g * m2 * _0008) / (l2 * m2 * _0011 + l2 * m1)]];\n"
                 "}")
-           (->JavaScript eq :parameter-order '[t theta phi thetadot phidot]))))
+           (->JavaScript eq
+                         :parameter-order '[t theta phi thetadot phidot]
+                         :deterministic? true))))
 
   (let [eq (simplify
             ((double/state-derivative 1 1 1 1 'g)
@@ -103,7 +105,7 @@
                 "  var _0016 = _0015 + -2;\n"
                 "  return [1, [thetadot, phidot], [(_0007 * _0013 * _0011 - g * _0011 * _0009 + _0006 * _0013 + 2 * g * _000a) / _0016, (- _0006 * _0013 * _0011 -2 * g * _000a * _0011 -2 * _0007 * _0013 + 2 * g * _0009) / _0016]];\n"
                 "}")
-           (->JavaScript eq))))
+           (->JavaScript eq :deterministic? true))))
 
   (let [eq (simplify
             ((Hamiltonian->state-derivative
@@ -137,4 +139,6 @@
                 "  var _0039 = _0037 + _0036 + _0035 + _001b + _001d;\n"
                 "  return [1, [(- l_1 * p_psi * _0029 + l_2 * p_theta) / (_000d * l_2 * m_2 * _0034 + _000d * l_2 * m_1), (- l_2 * m_2 * p_theta * _0029 + l_1 * m_1 * p_psi + l_1 * m_2 * p_psi) / (l_1 * _000f * _0012 * _0034 + l_1 * _000f * m_1 * m_2)], [(- g * _000e * _000f * m_1 * _0012 * _0018 * _0033 - g * _000e * _000f * _0013 * _0018 * _0033 + 2 * g * _000e * _000f * _0011 * m_2 * _0018 * _0032 + 4 * g * _000e * _000f * m_1 * _0012 * _0018 * _0032 + 2 * g * _000e * _000f * _0013 * _0018 * _0032 - g * _000e * _000f * Math.pow(m_1, 3) * _0018 -3 * g * _000e * _000f * _0011 * m_2 * _0018 -3 * g * _000e * _000f * m_1 * _0012 * _0018 - g * _000e * _000f * _0013 * _0018 - l_1 * l_2 * m_2 * p_psi * p_theta * _0032 * _002d + _000d * m_1 * _0014 * _0029 * _002d + _000d * m_2 * _0014 * _0029 * _002d + _000f * m_2 * _0015 * _0029 * _002d - l_1 * l_2 * m_1 * p_psi * p_theta * _002d - l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039, (- g * _000d * _0010 * _0013 * _0033 * _0017 -2 * g * _000d * _0010 * m_1 * _0012 * _0034 * _0017 + 2 * g * _000d * _0010 * _0013 * _0032 * _0017 - g * _000d * _0010 * _0011 * m_2 * _0017 - g * _000d * _0010 * _0013 * _0017 + l_1 * l_2 * m_2 * p_psi * p_theta * _0032 * _002d - _000d * m_1 * _0014 * _0029 * _002d - _000d * m_2 * _0014 * _0029 * _002d - _000f * m_2 * _0015 * _0029 * _002d + l_1 * l_2 * m_1 * p_psi * p_theta * _002d + l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039]];\n"
                 "}")
-           (->JavaScript eq :parameter-order '[theta psi p_theta p_psi])))))
+           (->JavaScript eq
+                         :parameter-order '[theta psi p_theta p_psi]
+                         :deterministic? true)))))

--- a/test/sicmutils/examples/double_pendulum_test.clj
+++ b/test/sicmutils/examples/double_pendulum_test.clj
@@ -71,68 +71,70 @@
 
 (deftest infix-forms
   (let [eq (simplify
-             ((double/state-derivative 'm1 'm2 'l1 'l2 'g)
-               (up 't (up 'theta 'phi) (up 'thetadot 'phidot))))]
+            ((double/state-derivative 'm1 'm2 'l1 'l2 'g)
+             (up 't (up 'theta 'phi) (up 'thetadot 'phidot))))]
     (is (= (str "function(t, theta, phi, thetadot, phidot) {\n"
-                "  var _0002 = Math.pow(phidot, 2);\n"
-                "  var _0003 = Math.sin(phi);\n"
-                "  var _0005 = - phi;\n"
-                "  var _0007 = Math.sin(theta);\n"
-                "  var _0008 = Math.pow(thetadot, 2);\n"
-                "  var _000b = _0005 + theta;\n"
-                "  var _000e = Math.cos(_000b);\n"
-                "  var _000f = Math.sin(_000b);\n"
-                "  var _0011 = Math.pow(_000f, 2);\n"
-                "  return [1, [thetadot, phidot], [(- l1 * m2 * _0008 * _000f * _000e - l2 * m2 * _0002 * _000f + g * m2 * _000e * _0003 - g * m1 * _0007 - g * m2 * _0007) / (l1 * m2 * _0011 + l1 * m1), (l2 * m2 * _0002 * _000f * _000e + l1 * m1 * _0008 * _000f + l1 * m2 * _0008 * _000f + g * m1 * _0007 * _000e + g * m2 * _0007 * _000e - g * m1 * _0003 - g * m2 * _0003) / (l2 * m2 * _0011 + l2 * m1)]];\n"
+                "  var _0001 = - phi;\n"
+                "  var _0005 = Math.pow(phidot, 2);\n"
+                "  var _0006 = Math.pow(thetadot, 2);\n"
+                "  var _0008 = Math.sin(phi);\n"
+                "  var _0009 = Math.sin(theta);\n"
+                "  var _000a = _0001 + theta;\n"
+                "  var _000e = Math.cos(_000a);\n"
+                "  var _0010 = Math.sin(_000a);\n"
+                "  var _0011 = Math.pow(_0010, 2);\n"
+                "  return [1, [thetadot, phidot], [(- l1 * m2 * _0006 * _0010 * _000e - l2 * m2 * _0005 * _0010 + g * m2 * _000e * _0008 - g * m1 * _0009 - g * m2 * _0009) / (l1 * m2 * _0011 + l1 * m1), (l2 * m2 * _0005 * _0010 * _000e + l1 * m1 * _0006 * _0010 + l1 * m2 * _0006 * _0010 + g * m1 * _0009 * _000e + g * m2 * _0009 * _000e - g * m1 * _0008 - g * m2 * _0008) / (l2 * m2 * _0011 + l2 * m1)]];\n"
                 "}")
            (->JavaScript eq :parameter-order '[t theta phi thetadot phidot]))))
+
   (let [eq (simplify
-             ((double/state-derivative 1 1 1 1 'g)
-               (up 't (up 'theta 'phi) (up 'thetadot 'phidot))))]
+            ((double/state-derivative 1 1 1 1 'g)
+             (up 't (up 'theta 'phi) (up 'thetadot 'phidot))))]
     (is (= (str "function(g, phi, phidot, theta, thetadot) {\n"
-                "  var _0002 = Math.pow(phidot, 2);\n"
-                "  var _0003 = Math.sin(phi);\n"
-                "  var _0005 = - phi;\n"
-                "  var _0006 = Math.sin(theta);\n"
-                "  var _0008 = Math.pow(thetadot, 2);\n"
-                "  var _000c = _0005 + theta;\n"
-                "  var _0012 = Math.sin(_000c);\n"
-                "  var _0013 = Math.cos(_000c);\n"
-                "  var _0015 = Math.pow(_0013, 2);\n"
+                "  var _0001 = - phi;\n"
+                "  var _0006 = Math.pow(phidot, 2);\n"
+                "  var _0007 = Math.pow(thetadot, 2);\n"
+                "  var _0009 = Math.sin(phi);\n"
+                "  var _000a = Math.sin(theta);\n"
+                "  var _000c = _0001 + theta;\n"
+                "  var _0011 = Math.cos(_000c);\n"
+                "  var _0013 = Math.sin(_000c);\n"
+                "  var _0015 = Math.pow(_0011, 2);\n"
                 "  var _0016 = _0015 + -2;\n"
-                "  return [1, [thetadot, phidot], [(_0008 * _0012 * _0013 - g * _0013 * _0003 + _0002 * _0012 + 2 * g * _0006) / _0016, (- _0002 * _0012 * _0013 -2 * g * _0006 * _0013 -2 * _0008 * _0012 + 2 * g * _0003) / _0016]];\n}"
-                )
+                "  return [1, [thetadot, phidot], [(_0007 * _0013 * _0011 - g * _0011 * _0009 + _0006 * _0013 + 2 * g * _000a) / _0016, (- _0006 * _0013 * _0011 -2 * g * _000a * _0011 -2 * _0007 * _0013 + 2 * g * _0009) / _0016]];\n"
+                "}")
            (->JavaScript eq))))
+
   (let [eq (simplify
             ((Hamiltonian->state-derivative
               (Lagrangian->Hamiltonian
                (double/L 'm_1 'm_2 'l_1 'l_2 'g)))
              (->H-state 't (up 'theta 'psi) (down 'p_theta 'p_psi))))]
     (is (= (str "function(theta, psi, p_theta, p_psi) {\n"
-                "  var _0004 = Math.pow(m_1, 2);\n"
-                "  var _0006 = Math.pow(l_2, 2);\n"
-                "  var _0007 = - psi;\n"
-                "  var _000a = Math.pow(p_psi, 2);\n"
-                "  var _000b = Math.pow(l_1, 2);\n"
-                "  var _000c = Math.sin(psi);\n"
-                "  var _000d = Math.pow(m_2, 3);\n"
-                "  var _000e = Math.pow(l_2, 3);\n"
-                "  var _0012 = Math.sin(theta);\n"
-                "  var _0013 = Math.pow(p_theta, 2);\n"
-                "  var _0014 = Math.pow(m_2, 2);\n"
-                "  var _0017 = Math.pow(l_1, 3);\n"
-                "  var _0019 = _0007 + theta;\n"
-                "  var _001c = _000b * _0006 * _0014;\n"
-                "  var _0023 = _000b * _0006 * _0004;\n"
-                "  var _002b = Math.cos(_0019);\n"
-                "  var _002d = Math.sin(_0019);\n"
-                "  var _002e = Math.pow(_002b, 4);\n"
-                "  var _0030 = Math.pow(_002b, 2);\n"
-                "  var _0033 = Math.pow(_002d, 2);\n"
-                "  var _0035 = _000b * _0006 * _0014 * _002e;\n"
-                "  var _0036 = -2 * _000b * _0006 * _0014 * _0030;\n"
-                "  var _0038 = 2 * _000b * _0006 * m_1 * m_2 * _0033;\n"
-                "  var _0039 = _0035 + _0038 + _0036 + _0023 + _001c;\n"
-                "  return [1, [(- l_1 * p_psi * _002b + l_2 * p_theta) / (_000b * l_2 * m_2 * _0033 + _000b * l_2 * m_1), (- l_2 * m_2 * p_theta * _002b + l_1 * m_1 * p_psi + l_1 * m_2 * p_psi) / (l_1 * _0006 * _0014 * _0033 + l_1 * _0006 * m_1 * m_2)], [(- g * _0017 * _0006 * m_1 * _0014 * _0012 * _002e - g * _0017 * _0006 * _000d * _0012 * _002e + 2 * g * _0017 * _0006 * _0004 * m_2 * _0012 * _0030 + 4 * g * _0017 * _0006 * m_1 * _0014 * _0012 * _0030 + 2 * g * _0017 * _0006 * _000d * _0012 * _0030 - g * _0017 * _0006 * Math.pow(m_1, 3) * _0012 -3 * g * _0017 * _0006 * _0004 * m_2 * _0012 -3 * g * _0017 * _0006 * m_1 * _0014 * _0012 - g * _0017 * _0006 * _000d * _0012 - l_1 * l_2 * m_2 * p_psi * p_theta * _0030 * _002d + _000b * m_1 * _000a * _002b * _002d + _000b * m_2 * _000a * _002b * _002d + _0006 * m_2 * _0013 * _002b * _002d - l_1 * l_2 * m_1 * p_psi * p_theta * _002d - l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039, (- g * _000b * _000e * _000d * _002e * _000c -2 * g * _000b * _000e * m_1 * _0014 * _0033 * _000c + 2 * g * _000b * _000e * _000d * _0030 * _000c - g * _000b * _000e * _0004 * m_2 * _000c - g * _000b * _000e * _000d * _000c + l_1 * l_2 * m_2 * p_psi * p_theta * _0030 * _002d - _000b * m_1 * _000a * _002b * _002d - _000b * m_2 * _000a * _002b * _002d - _0006 * m_2 * _0013 * _002b * _002d + l_1 * l_2 * m_1 * p_psi * p_theta * _002d + l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039]];\n"
+                "  var _0004 = - psi;\n"
+                "  var _000d = Math.pow(l_1, 2);\n"
+                "  var _000e = Math.pow(l_1, 3);\n"
+                "  var _000f = Math.pow(l_2, 2);\n"
+                "  var _0010 = Math.pow(l_2, 3);\n"
+                "  var _0011 = Math.pow(m_1, 2);\n"
+                "  var _0012 = Math.pow(m_2, 2);\n"
+                "  var _0013 = Math.pow(m_2, 3);\n"
+                "  var _0014 = Math.pow(p_psi, 2);\n"
+                "  var _0015 = Math.pow(p_theta, 2);\n"
+                "  var _0017 = Math.sin(psi);\n"
+                "  var _0018 = Math.sin(theta);\n"
+                "  var _001b = _000d * _000f * _0011;\n"
+                "  var _001d = _000d * _000f * _0012;\n"
+                "  var _001f = _0004 + theta;\n"
+                "  var _0029 = Math.cos(_001f);\n"
+                "  var _002d = Math.sin(_001f);\n"
+                "  var _0032 = Math.pow(_0029, 2);\n"
+                "  var _0033 = Math.pow(_0029, 4);\n"
+                "  var _0034 = Math.pow(_002d, 2);\n"
+                "  var _0035 = -2 * _000d * _000f * _0012 * _0032;\n"
+                "  var _0036 = 2 * _000d * _000f * m_1 * m_2 * _0034;\n"
+                "  var _0037 = _000d * _000f * _0012 * _0033;\n"
+                "  var _0039 = _0037 + _0036 + _0035 + _001b + _001d;\n"
+                "  return [1, [(- l_1 * p_psi * _0029 + l_2 * p_theta) / (_000d * l_2 * m_2 * _0034 + _000d * l_2 * m_1), (- l_2 * m_2 * p_theta * _0029 + l_1 * m_1 * p_psi + l_1 * m_2 * p_psi) / (l_1 * _000f * _0012 * _0034 + l_1 * _000f * m_1 * m_2)], [(- g * _000e * _000f * m_1 * _0012 * _0018 * _0033 - g * _000e * _000f * _0013 * _0018 * _0033 + 2 * g * _000e * _000f * _0011 * m_2 * _0018 * _0032 + 4 * g * _000e * _000f * m_1 * _0012 * _0018 * _0032 + 2 * g * _000e * _000f * _0013 * _0018 * _0032 - g * _000e * _000f * Math.pow(m_1, 3) * _0018 -3 * g * _000e * _000f * _0011 * m_2 * _0018 -3 * g * _000e * _000f * m_1 * _0012 * _0018 - g * _000e * _000f * _0013 * _0018 - l_1 * l_2 * m_2 * p_psi * p_theta * _0032 * _002d + _000d * m_1 * _0014 * _0029 * _002d + _000d * m_2 * _0014 * _0029 * _002d + _000f * m_2 * _0015 * _0029 * _002d - l_1 * l_2 * m_1 * p_psi * p_theta * _002d - l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039, (- g * _000d * _0010 * _0013 * _0033 * _0017 -2 * g * _000d * _0010 * m_1 * _0012 * _0034 * _0017 + 2 * g * _000d * _0010 * _0013 * _0032 * _0017 - g * _000d * _0010 * _0011 * m_2 * _0017 - g * _000d * _0010 * _0013 * _0017 + l_1 * l_2 * m_2 * p_psi * p_theta * _0032 * _002d - _000d * m_1 * _0014 * _0029 * _002d - _000d * m_2 * _0014 * _0029 * _002d - _000f * m_2 * _0015 * _0029 * _002d + l_1 * l_2 * m_1 * p_psi * p_theta * _002d + l_1 * l_2 * m_2 * p_psi * p_theta * _002d) / _0039]];\n"
                 "}")
            (->JavaScript eq :parameter-order '[theta psi p_theta p_psi])))))

--- a/test/sicmutils/infix_test.cljc
+++ b/test/sicmutils/infix_test.cljc
@@ -240,31 +240,17 @@
         (is (= (format "%s dx² ∂₀(∂₀f)(up(x, y)) + dx dy ∂₁(∂₀f)(up(x, y)) + %s dy² ∂₁(∂₁f)(up(x, y)) + dx ∂₀f(up(x, y)) + dy ∂₁f(up(x, y)) + f(up(x, y))" half half)
                (s->infix expr)))
 
-        ;; TODO there is some difference happening internally in the simplifier,
-        ;; probably due to some difference in equality between cljs and clj,
-        ;; that is causing the variables to resolve differently. We're in a
-        ;; functional language, and we want everything to work EXACTLY the
-        ;; same... so this is a passing test, but also a bug.
-        ;;
         ;; TODO once we get fractional support, render fractions correctly. Or,
         ;; since cljs *is* js, consider doing something different here.
-        (is (= #?(:clj
-                  (str "function(dx, dy, f, partial, x, y) {\n"
-                       "  var _0003 = partial(0);\n"
-                       "  var _0004 = [x, y];\n"
-                       "  var _0005 = partial(1);\n"
-                       "  var _0006 = _0005(f);\n"
-                       "  var _0007 = _0003(f);\n"
-                       "  return 1/2 * Math.pow(dx, 2) * _0003(_0007)(_0004) + dx * dy * _0005(_0007)(_0004) + 1/2 * Math.pow(dy, 2) * _0005(_0006)(_0004) + dx * _0007(_0004) + dy * _0006(_0004) + f(_0004);\n}")
-
-                  :cljs
-                  (str "function(dx, dy, f, partial, x, y) {\n"
-                       "  var _0002 = partial(0);\n"
-                       "  var _0003 = [x, y];\n"
-                       "  var _0004 = partial(1);\n"
-                       "  var _0006 = _0002(f);\n"
-                       "  var _0007 = _0004(f);\n"
-                       "  return 0.5 * Math.pow(dx, 2) * _0002(_0006)(_0003) + dx * dy * _0004(_0006)(_0003) + 0.5 * Math.pow(dy, 2) * _0004(_0007)(_0003) + dx * _0006(_0003) + dy * _0007(_0003) + f(_0003);\n}"))
+        (is (= (format
+                (str "function(dx, dy, f, partial, x, y) {\n"
+                     "  var _0003 = partial(0);\n"
+                     "  var _0004 = partial(1);\n"
+                     "  var _0005 = [x, y];\n"
+                     "  var _0006 = _0003(f);\n"
+                     "  var _0007 = _0004(f);\n"
+                     "  return %s * Math.pow(dx, 2) * _0003(_0006)(_0005) + dx * dy * _0004(_0006)(_0005) + %s * Math.pow(dy, 2) * _0004(_0007)(_0005) + dx * _0006(_0005) + dy * _0007(_0005) + f(_0005);\n}")
+                half half)
                (s->JS expr)))
 
         (is (= (format "%s\\,{dx}^{2}\\,\\partial_0\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,dy\\,\\partial_1\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + %s\\,{dy}^{2}\\,\\partial_1\\left(\\partial_1f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,\\partial_0f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dy\\,\\partial_1f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right)"

--- a/test/sicmutils/infix_test.cljc
+++ b/test/sicmutils/infix_test.cljc
@@ -251,7 +251,7 @@
                      "  var _0007 = _0004(f);\n"
                      "  return %s * Math.pow(dx, 2) * _0003(_0006)(_0005) + dx * dy * _0004(_0006)(_0005) + %s * Math.pow(dy, 2) * _0004(_0007)(_0005) + dx * _0006(_0005) + dy * _0007(_0005) + f(_0005);\n}")
                 half half)
-               (s->JS expr)))
+               (s->JS expr :deterministic? true)))
 
         (is (= (format "%s\\,{dx}^{2}\\,\\partial_0\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,dy\\,\\partial_1\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + %s\\,{dy}^{2}\\,\\partial_1\\left(\\partial_1f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,\\partial_0f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dy\\,\\partial_1f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right)"
                        tex-half tex-half)


### PR DESCRIPTION
This bit me in the double pendulum tests. I didn't change the default behavior, but added an option that lets us control the variable order.