### PR TITLE
Refactor `sicmutils.ode` to make it easier to explicitly trigger integration (1b)

### DIFF
--- a/src/sicmutils/numerical/ode.cljc
+++ b/src/sicmutils/numerical/ode.cljc
@@ -52,19 +52,20 @@
      (let [array->state #(struct/unflatten % initial-state)]
        (reify StepHandler
          (init [_ _ _ _])
-         (handleStep [_ interpolator is-last]
+         (handleStep [_ interpolator final-step?]
            (let [it0         (.getPreviousTime interpolator)
                  it1         (.getCurrentTime interpolator)
                  t0          (round-up it0 step-size)
-                 final-state (array->state
-                              (.getInterpolatedState interpolator))]
+                 final-state (when final-step?
+                               (array->state
+                                (.getInterpolatedState interpolator)))]
              (doseq [t (range t0 it1 step-size)]
                (.setInterpolatedTime interpolator t)
                (observe t (array->state
                            (.getInterpolatedState interpolator))))
              ;; `range` has an exclusive upper bound, so the final point will
              ;; never be observed in the `doseq`. Handle it here.
-             (when is-last
+             (when final-step?
                (observe it1 final-state))))))))
 
 #?(:clj


### PR DESCRIPTION
This PR locks in a refactor that I used to integrate (yuk yuk) `sicmutils` with the Quil animation library:

https://github.com/sritchie/maturin/blob/master/src/maturin/better.clj#L33-L47

@littleredcomputer , I'm treading lightly since I know I'm in your domain now! Please treat this as a suggestion, not a final API that the Clojurescript port has to conform to.