### PR TITLE
Added algebraic laws, #sicm/bigint literal, tests for all numeric types (3)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
 (defproject net.littleredcomputer/sicmutils "0.12.2-SNAPSHOT"
   :description "A port of the Scmutils computer algebra/mechanics system to Clojure"
   :url "http://github.com/littleredcomputer/sicmutils"
+  :scm {:name "git" :url "https://github.com/littleredcomputer/sicmutils"}
   :license {:name "GPLv3"
             :url "http://www.opensource.org/licenses/GPL-3.0"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]

--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,9 @@
                                                   #"sicmutils.simplify"]}
                    :repl-options {:nrepl-middleware
                                   [cider.piggieback/wrap-cljs-repl]}
-                   :dependencies [[org.clojure/test.check "1.0.0"]
+                   :dependencies [[org.clojure/test.check "1.1.0"]
+                                  [com.gfredericks/test.chuck "0.2.10"]
+                                  [same/ish "0.1.4"]
                                   [criterium "0.4.5"]
                                   [cider/piggieback "0.5.0"]
                                   [lein-doo "0.1.11"]]}

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,0 +1,1 @@
+{sicm/complex sicmutils.complex/parse-complex}

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,1 +1,2 @@
-{sicm/complex sicmutils.complex/parse-complex}
+{sicm/complex sicmutils.complex/parse-complex
+ sicm/bigint  sicmutils.util/parse-bigint}

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -50,6 +50,5 @@
 ;; multimethod implementation for basic numeric types.
 (defmethod g/gcd :default [a b] (gcd a b))
 
-(defn lcm
-  [a b]
-  (g/abs (g/divide (g/* a b) (gcd a b))))
+(defmethod g/lcm :default [a b]
+  (g/abs (g/divide (g/* a b) (g/gcd a b))))

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -61,13 +61,20 @@
   "Defines a multifn using the provided symbol. Arranges for the multifn
   to answer the :arity message, reporting either [:exactly a] or
   [:between a b], according to the arguments given."
-  [f a & b]
-  (let [arity (if b `[:between ~a ~@b] [:exactly a])
-        docstring (str "generic " f)
-        klass (fork :clj clojure.lang.Keyword :cljs 'cljs.core/Keyword)]
+  {:arglists '([name arities docstring? attr-map? & options])}
+  [f arities & options]
+  (let [[a b] (if (vector? arities) arities [arities])
+        arity     (if b [:between a b] [:exactly a])
+        docstring (if (string? (first options))
+                    (str "generic " f ".\n\n" (first options))
+                    (str "generic " f ))
+        options (if (string? (first options))
+                  (next options)
+                  options)
+        kwd-klass (fork :clj clojure.lang.Keyword :cljs 'cljs.core/Keyword)]
     `(do
-       (defmulti ~f ~docstring v/argument-kind)
-       (defmethod ~f [~klass] [k#]
+       (defmulti ~f ~docstring v/argument-kind ~@options)
+       (defmethod ~f [~kwd-klass] [k#]
          ({:arity ~arity :name '~f} k#)))))
 
 ;; Numeric functions.
@@ -76,7 +83,12 @@
 (def-generic-function sub 2)
 (def-generic-function div 2)
 (def-generic-function negate 1)
-(def-generic-function negative? 1)
+(def-generic-function negative? 1
+  "Returns true if the argument `a` is less than `(v/zero-like a), false
+  otherwise. The default implementation depends on a proper Comparable
+  implementation on the type.`")
+(defmethod negative? :default [a] (< a (v/zero-like a)))
+
 (def-generic-function exp 1)
 (def-generic-function log 1)
 (def-generic-function abs 1)
@@ -95,6 +107,7 @@
 
 (def-generic-function expt 2)
 (def-generic-function gcd 2)
+(def-generic-function lcm 2)
 (def-generic-function exact-divide 2)
 
 (def-generic-function square 1)
@@ -109,7 +122,7 @@
 (def-generic-function tan 1)
 (def-generic-function asin 1)
 (def-generic-function acos 1)
-(def-generic-function atan 1 2)
+(def-generic-function atan [1 2])
 
 ;; Operations on structures
 (def-generic-function invert 1)

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -85,13 +85,17 @@
   ;; a generic operation (along with lcm), and binding the euclid implmentation
   ;; in for language supported integral types. Perhaps also generalizing ratio?
   ;; and denominator. TODO.
+  ;;
+  ;; (note from sritchie: I don't think this is true anymore, as of 8.26.20.
+  ;; Should we remove the comment, or is there some more work to do to make this
+  ;; more efficient?)
   (let [arity (.-arity u)
         cv (p/coefficients v)
         lcv (last cv)
         cs (into (into #{} cv) (p/coefficients u))
         integerizing-factor (g/*
                              (if (< lcv 0) -1 1)
-                             (reduce euclid/lcm 1 (map u/denominator (filter u/ratio? cs))))
+                             (reduce g/lcm 1 (map u/denominator (filter u/ratio? cs))))
         u' (if (not (v/unity? integerizing-factor)) (p/map-coefficients #(g/* integerizing-factor %) u) u)
         v' (if (not (v/unity? integerizing-factor)) (p/map-coefficients #(g/* integerizing-factor %) v) v)
         g (poly/gcd u' v')

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -51,6 +51,9 @@
   #?(:clj (core-bigint x)
      :cljs (js/BigInt x)))
 
+(defn parse-bigint [x]
+  `(bigint ~x))
+
 (def ratio?
   #?(:clj core-ratio?
      :cljs (constantly false)))

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -155,7 +155,7 @@
 
 ;; These two constitute the default cases.
 (defmethod eq [::number ::number] [l r]
-  #?(:clj (= l r)
+  #?(:clj  (= l r)
      :cljs (identical? l r)))
 
 (defmethod eq :default [l r]
@@ -178,8 +178,8 @@
                           [::native-integral goog.math.Long u/long]
                           [goog.math.Long js/BigInt u/bigint]
                           [goog.math.Integer js/BigInt u/bigint]]]
-       (defmethod eq [from to] [l r] (eq (f l) r))
-       (defmethod eq [to from] [l r] (eq l (f r))))
+       (defmethod eq [from to] [l r] (= (f l) r))
+       (defmethod eq [to from] [l r] (= l (f r))))
 
      (extend-protocol IEquiv
        number

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -19,6 +19,7 @@
 
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]
+            #?(:cljs [cljs.reader :refer [read-string]])
             [sicmutils.numbers]
             [sicmutils.complex :as c]
             [sicmutils.generic :as g]
@@ -28,15 +29,25 @@
 (defn ^:private near [w z]
   (< (g/abs (g/- w z)) 1e-12))
 
+(deftest complex-literal
+  (testing "parse-complex can round-trip Complex instances. These show up as
+  code snippets when you call `read-string` directly, and aren't evaluated into
+  Clojure. The fork in the test here captures the different behavior that will
+  appear in evaluated Clojure, vs self-hosted Clojurescript."
+    (is (= #?(:clj  '(sicmutils.complex/complex 1.0 2.0)
+              :cljs '(sicmutils.complex/complex "1 + 2i"))
+           (read-string {:readers {'sicm/complex c/parse-complex}}
+                        (pr-str #sicm/complex "1 + 2i"))))))
+
 (deftest value-protocol
   (testing "v/Value protocol implementation"
     (is (v/nullity? c/ZERO))
-    (is (v/nullity? (c/complex 0.0)))
+    (is (v/nullity? #sicm/complex "0"))
     (is (not (v/nullity? c/ONE)))
     (is (not (v/nullity? (c/complex 1.0))))
     (is (v/nullity? (v/zero-like (c/complex 100))))
     (is (= c/ZERO (v/zero-like (c/complex 2))))
-    (is (= c/ZERO (v/zero-like (c/complex 0 3.14))))
+    (is (= c/ZERO (v/zero-like #sicm/complex "0 + 3.14i")))
 
     (is (v/unity? c/ONE))
     (is (v/unity? (c/complex 1.0)))
@@ -59,13 +70,13 @@
           [(is (v/exact? (c/complex 10)))
            (is (v/exact? (c/complex 10 12)))]))))
 
-(let [i (c/complex 0 1)
+(let [i #sicm/complex "1i"
       pi Math/PI]
   (deftest complex-numbers
     (testing "complex constructor and predicate"
       (is (c/complex? c/ONE))
-      (is (c/complex? (c/complex 0 1)))
-      (is (c/complex? (c/complex 2)))
+      (is (c/complex? i))
+      (is (c/complex? #sicm/complex "2"))
       (is (not (c/complex? 4))))
 
     (testing "complex-generics"
@@ -74,7 +85,9 @@
         (gt/floating-point-tests c/complex :eq near)))
 
     (testing "add"
-      (is (= (c/complex 4 6) (g/add (c/complex 1 2) (c/complex 3 4))))
+      (is (= #sicm/complex "4 + 6i"
+             (g/add #sicm/complex "1 + 2i"
+                    #sicm/complex "3 + 4i")))
       (is (= (c/complex 1 3) (g/add (c/complex 0 3) 1)))
       (is (= (c/complex 1 3)
              (g/add 1 (c/complex 0 3))

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -20,10 +20,14 @@
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]
             #?(:cljs [cljs.reader :refer [read-string]])
+            [same :refer [with-comparator]]
+            [same.compare :as sc]
             [sicmutils.numbers]
             [sicmutils.complex :as c]
             [sicmutils.generic :as g]
             [sicmutils.generic-test :as gt]
+            [sicmutils.generators :as sg]
+            [sicmutils.laws :as l]
             [sicmutils.value :as v]))
 
 (defn ^:private near [w z]
@@ -38,6 +42,12 @@
               :cljs '(sicmutils.complex/complex "1 + 2i"))
            (read-string {:readers {'sicm/complex c/parse-complex}}
                         (pr-str #sicm/complex "1 + 2i"))))))
+
+(deftest complex-laws
+  ;; Complex numbers form a field. We use a custom comparator to control some
+  ;; precision loss.
+  (with-comparator (sc/compare-ulp 1.0 1e3)
+    (l/field 100 sg/complex "Complex")))
 
 (deftest value-protocol
   (testing "v/Value protocol implementation"

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -70,7 +70,7 @@
           [(is (v/exact? (c/complex 10)))
            (is (v/exact? (c/complex 10 12)))]))))
 
-(let [i #sicm/complex "1i"
+(let [i #sicm/complex "0 + 1i"
       pi Math/PI]
   (deftest complex-numbers
     (testing "complex constructor and predicate"

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -20,8 +20,6 @@
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]
             #?(:cljs [cljs.reader :refer [read-string]])
-            [same :refer [with-comparator]]
-            [same.compare :as sc]
             [sicmutils.numbers]
             [sicmutils.complex :as c]
             [sicmutils.generic :as g]
@@ -46,7 +44,7 @@
 (deftest complex-laws
   ;; Complex numbers form a field. We use a custom comparator to control some
   ;; precision loss.
-  (with-comparator (sc/compare-ulp 1.0 1e3)
+  (binding [sg/*complex-tolerance* 1e-3]
     (l/field 100 sg/complex "Complex")))
 
 (deftest value-protocol

--- a/test/sicmutils/euclid_test.cljc
+++ b/test/sicmutils/euclid_test.cljc
@@ -29,9 +29,9 @@
   y with the returned Bézout coefficients"
   [x y]
   (let [[g a b] (e/extended-gcd x y)]
-    (and (= 0 (mod x g))
-         (= 0 (mod y g))
-         (= g (+ (* a x) (* b y)))
+    (and (= 0 (g/modulo x g))
+         (= 0 (g/modulo y g))
+         (= g (g/+ (g/* a x) (g/* b y)))
          g)))
 
 (deftest euclid-test
@@ -63,15 +63,17 @@
     (is (= [2 1 0] (e/extended-gcd 2 4))))
 
   (testing "lcm"
-    (is (= 21 (e/lcm 3 7)))
-    (is (= 6 (e/lcm 2 6)))
-    (is (= 8 (e/lcm 2 8)))
-    (is (= 30 (e/lcm 6 15)))
-    (is (= 12 (reduce e/lcm [2 3 4])))
-    (is (= 30 (reduce e/lcm [2 3 5]))))
+    (is (= 21 (g/lcm 3 7)))
+    (is (= 6 (g/lcm 2 6)))
+    (is (= 8 (g/lcm 2 8)))
+    (is (= 30 (g/lcm 6 15)))
+    (is (= 12 (reduce g/lcm [2 3 4])))
+    (is (= 30 (reduce g/lcm [2 3 5]))))
 
-  ;; CLJS can't currently handle the precision of these numbers.
-  #?(:clj
-     (testing "high precision gcd"
-       (is (= (ok 37279462087332 366983722766) 564958))
-       (is (= (ok 4323874085395 586898689868986900219865) 85)))))
+  (testing "high precision gcd"
+    (is (= (ok #sicm/bigint 37279462087332
+               #sicm/bigint 366983722766)
+           564958))
+    (is (= (ok #sicm/bigint 4323874085395
+               #sicm/bigint "586898689868986900219865")
+           85))))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -8,6 +8,7 @@
   (:require [clojure.test.check.generators :as gen]
             [same.ish :as si]
             [sicmutils.complex :as c]
+            [sicmutils.generic :as g]
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
@@ -56,6 +57,8 @@
             i (reasonable-double)]
     (c/complex r i)))
 
+(def ^:dynamic *complex-tolerance* 1e-12)
+
 (extend-protocol si/Approximate
   #?@(:cljs
       [js/BigInt
@@ -64,7 +67,5 @@
 
   #?(:cljs c/complextype :clj Complex)
   (ish [this that]
-    (and (si/ish (c/real-part this)
-                 (c/real-part that))
-         (si/ish (c/imag-part this)
-                 (c/imag-part that)))))
+    (< (g/abs (g/- this that))
+       *complex-tolerance*)))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -1,2 +1,70 @@
 (ns sicmutils.generators
-  )
+  "test.check generators for the various types in the sicmutils project."
+  (:refer-clojure :rename {bigint core-bigint
+                           biginteger core-biginteger
+                           double core-double
+                           long core-long}
+                  #?@(:cljs [:exclude [bigint double long]]))
+  (:require [clojure.test.check.generators :as gen]
+            [same.ish :as si]
+            [sicmutils.complex :as c]
+            [sicmutils.util :as u]
+            [sicmutils.value :as v])
+  #?(:clj
+     (:import [org.apache.commons.math3.complex Complex])))
+
+(def bigint
+  "js/BigInt in cljs, clojure.lang.BigInt in clj."
+  #?(:cljs
+     (gen/fmap u/bigint gen/large-integer)
+     :clj
+     gen/size-bounded-bigint))
+
+#?(:clj
+   (def biginteger
+     (gen/fmap u/biginteger bigint)))
+
+(def native-integral
+  "non-floating-point integers on cljs, Long on clj."
+  gen/large-integer)
+
+(def long
+  "goog.math.Long in cljs,
+  java.lang.Long in clj."
+  #?(:clj gen/large-integer
+     :cljs (gen/fmap u/long gen/large-integer)))
+
+(def integer
+  "goog.math.Integer in cljs, java.lang.Integer in clj."
+  (gen/fmap u/int gen/small-integer))
+
+(defn reasonable-double [& {:keys [min max]
+                            :or {min -10e5
+                                 max 10e5}}]
+  (let [[excluded-lower excluded-upper] [-1e-4 1e-4]]
+    (gen/one-of [(gen/double* {:infinite? false
+                               :NaN? false
+                               :min min
+                               :max excluded-lower})
+                 (gen/double* {:infinite? false
+                               :NaN? false
+                               :min excluded-upper
+                               :max max})])))
+
+(def complex
+  (gen/let [r (reasonable-double)
+            i (reasonable-double)]
+    (c/complex r i)))
+
+(extend-protocol si/Approximate
+  #?@(:cljs
+      [js/BigInt
+       (ish [this that]
+            (= this that))])
+
+  #?(:cljs c/complextype :clj Complex)
+  (ish [this that]
+    (and (si/ish (c/real-part this)
+                 (c/real-part that))
+         (si/ish (c/imag-part this)
+                 (c/imag-part that)))))

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -20,7 +20,11 @@
 (ns sicmutils.generic-test
   (:refer-clojure :exclude [+ - * / zero?])
   (:require [clojure.test :refer [is deftest testing]]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]
+             #?@(:cljs [:include-macros true])]
             [sicmutils.generic :as g]
+            [sicmutils.laws :as l]
             [sicmutils.value :as v]))
 
 (defmulti s* v/argument-kind)
@@ -54,8 +58,7 @@
     (is (= "eceoeleienrcrorlrirnicioiliiinncnonlninn" (s* "erin" "colin"))))
   (testing "add"
     (is (= "foobar" (s+ "foo" "bar")))
-    (is (= "zzz" (s+ "" "zzz")))
-    ))
+    (is (= "zzz" (s+ "" "zzz")))))
 
 (deftest type-assigner
   (testing "types"
@@ -65,25 +68,43 @@
 
 (deftest generic-plus
   (is (= 0 (g/+)) "no args returns additive identity")
-  (is (= 3.14 (g/+ 3.14)) "single arg should return itself")
-  (is (= 10 (g/+ 0 10 0.0 0 0)) "multi-arg works, as long as zeros appear.")
-  (is (= "happy" (g/+ 0 "happy" 0.0 0 0)) "returns really anything."))
+  (checking "g/+"
+            100
+            [x gen/any]
+            (is (= x (g/+ x)) "single arg should return itself, for any type.")
+            (is (= (if (v/nullity? x) 0 x)
+                   (g/+ x 0))
+                "adding a 0 works for any input. The first zero element gets
+                returned.")
+            (is (= x (g/+ 0 x)) "adding a leading 0 acts as identity.")
+            (is (= (if (v/nullity? x) 0 x)
+                   (g/+ 0 x 0.0 0 0)) "multi-arg works as long as zeros
+            appear.")))
 
 (deftest generic-minus
   (is (= 0 (g/-)) "no-arity returns the additive identity.")
-  (is (= 10 (g/- 10 0)) "Subtracting a zero works, with no implementations registered.")
-  (is (= "face" (g/- "face" 0))))
+  (checking "Subtracting a zero acts as id, with no implementations registered."
+            100
+            [x gen/any]
+            (is (= x (g/- x 0)))))
 
 (deftest generic-times
   (is (= 1 (g/*)) "No args returns the multiplicative identity.")
-  (is (= 2 (g/* 2)) "single arg returns itself.")
-  (is (= 5 (g/* 5 1) (g/* 1 5)) "Anything times a 1 returns itself.")
-  (is (= "face" (g/* "face" 1) (g/* 1 "face")) "works for really anything."))
+  (checking "g/*"
+            100
+            [x gen/any]
+            (is (= x (g/* x)) "single arg returns itself.")
+            (is (= (if (v/unity? x) 1 x)
+                   (g/* x 1)) "First unity gets returned.")
+            (is (= x (g/* 1 x)) "Anything times a 1 returns itself.")))
 
 (deftest generic-divide
   (is (= 1 (g/divide)) "division with no args returns multiplicative identity")
-  (is (= 20 (g/divide 20 1)) "dividing by one a single time returns the input")
-  (is (= "face" (g/divide "face" 1 1 1 1.0 1)) "dividing by 1 returns the input"))
+  (checking "g/divide"
+            100
+            [x gen/any]
+            (is (= x (g/divide x 1)) "dividing by one a single time returns the input")
+            (is (= x (g/divide x 1 1 1 1.0 1)) "dividing by 1 returns the input")))
 
 (defn ^:private is* [eq actual expected]
   (is (eq actual expected)

--- a/test/sicmutils/laws.cljc
+++ b/test/sicmutils/laws.cljc
@@ -1,0 +1,263 @@
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.laws
+  "test.check laws useful for checking the algebraic properties of different types
+  that implement the sicmutils.generic operations, and the additive and
+  multiplicative options in sicmutils.value.Value."
+  (:require [clojure.test :refer [is deftest testing]]
+            [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]
+             #?@(:cljs [:include-macros true])]
+            [same :refer [ish? zeroish?]]
+            [sicmutils.generic :as g]
+            [sicmutils.value :as v]))
+
+(defn nullity [options generator type-name]
+  (checking (str type-name " v/nullity? agrees with v/zero-like.")
+            options
+            [a generator]
+            (is (v/nullity? (v/zero-like a)))))
+
+(defn unity [options generator type-name]
+  (checking (str type-name " v/unity? agrees with v/one-like.")
+            options
+            [a generator]
+            (is (v/unity? (v/one-like a)))))
+
+(defn zero-like [options generator type-name]
+  (nullity options generator type-name)
+  (checking (str type-name " has a valid zero-like implementation.")
+            options
+            [a generator]
+            (is (ish? a (g/add a (v/zero-like a))))
+            (is (ish? a (g/add (v/zero-like a) a)))))
+
+(defn one-like [options generator type-name]
+  (unity options generator type-name)
+  (checking (str type-name " has a valid one-like implementation.")
+            options
+            [a generator]
+            (is (ish? a (g/mul a (v/one-like a))))
+            (is (ish? a (g/mul (v/one-like a) a)))))
+
+(defn associative-add [options generator type-name]
+  (checking (str type-name " implements associative g/add.")
+            options
+            [a generator
+             b generator
+             c generator]
+            (is (ish? (g/add a (g/add b c))
+                      (g/add (g/add a b) c)))))
+
+(defn commutative-add [options generator type-name]
+  (checking (str type-name " implements commutative g/add.")
+            options
+            [a generator
+             b generator]
+            (is (ish? (g/add a b)
+                      (g/add b a)))))
+
+(defn associative-mul [options generator type-name]
+  (checking (str type-name " implements associative g/mul.")
+            options
+            [a generator
+             b generator
+             c generator]
+            (is (ish? (g/add a (g/add b c))
+                      (g/add (g/add a b) c)))))
+
+(defn commutative-mul [options generator type-name]
+  (checking (str type-name " implements commutative g/mul.")
+            options
+            [a generator
+             b generator]
+            (is (ish? (g/mul a b)
+                      (g/mul b a)))))
+
+(defn additive-inverse [options generator type-name]
+  (checking (str type-name " has additive inverses via g/negate and g/sub")
+            options
+            [a generator]
+            (is (ish? (v/zero-like a) (g/add a (g/negate a))))
+            (is (v/nullity? (g/add a (g/negate a))))
+            (is (ish? (v/zero-like a) (g/add (g/negate a) a)))
+            (is (ish? (v/zero-like a) (g/sub a a)))))
+
+(defn multiplicative-inverse [options generator type-name]
+  (checking (str type-name " has multiplicative inverses via g/div and g/invert (excluding zero.)")
+            options
+            [a generator :when (not (v/nullity? a))]
+            (is (ish? (v/one-like a) (g/mul a (g/invert a))))
+            (is (ish? (v/one-like a) (g/mul (g/invert a) a)))
+            (is (ish? (v/one-like a) (g/div a a)))))
+
+(defn mul-distributes-over-add [options generator type-name]
+  (checking (str type-name " g/mul distributes over g/add, left and right")
+            options
+            [a generator
+             b generator
+             c generator]
+            (is (ish? (g/mul a (g/add b c))
+                      (g/add (g/mul a b) (g/mul a c))))
+            (is (ish? (g/mul (g/add b c) a)
+                      (g/add (g/mul b a) (g/mul c a))))))
+
+;; These put the above laws together into known abstract-algebraic bundles.
+
+(defn additive-semigroup
+  "An additive semigroup is a type `a` with a `g/add` implementation that's
+  associative:
+
+      a + (b + c) == (a + b) + c
+
+  and, optionally, commutative:
+
+      a + b == b + a
+
+  a commutative semigroup is also called an \"abelian semigroup\"."
+  [opts generator type-name & {:keys [commutative?]}]
+  (associative-add opts generator type-name)
+  (when commutative?
+    (commutative-add opts generator type-name)))
+
+(defn additive-monoid
+  "an additive monoid is a type `a` with a \"zero\", that acts as an identity
+  element when added to any other element:
+
+      0 + a == a + 0 == a
+
+  `(v/zero-like a)` should always return this element,
+  and `(v/nullity? (v/zero-like))` should always be true.`"
+  [opts generator type-name & {:keys [commutative?]}]
+  (additive-semigroup opts generator type-name :commutative? commutative?)
+  (zero-like opts generator type-name))
+
+(defn multiplicative-semigroup
+  "A multiplicative semigroup is a type `a` with a `g/mul` implementation that's
+  associative:
+
+      a * (b * c) == (a * b) * c
+
+  and, optionally, commutative:
+
+      a * b == b * a
+
+  a commutative semigroup is also called an \"abelian semigroup\"."
+  [opts generator type-name & {:keys [commutative?]}]
+  (one-like opts generator type-name)
+  (associative-mul opts generator type-name)
+  (when commutative?
+    (commutative-mul opts generator type-name)))
+
+(defn multiplicative-monoid
+  "a multiplicative monoid is a type `a` with a \"one\", that acts as an identity
+  element when multiplied by any other element:
+
+      0 * a == a * 0 == a
+
+  `(v/one-like a)` should always return this element,
+  and `(v/unity? (v/one-like))` should always be true.`"
+  [opts generator type-name & {:keys [commutative?]}]
+  (multiplicative-semigroup opts generator type-name  :commutative? commutative?)
+  (one-like opts generator type-name))
+
+(defn additive-group
+  "An additive group is a type `a` that passes all of the laws in
+  `additive-monoid` (optionally commutative), and additionally can generate an
+  additive inverse for every element. `g/negate` returns the additive inverse.
+  The additional rules are:
+
+      a + (-a) == 0
+      (-a) + a == 0
+      a - a == 0
+
+  where `(-a)` is `(g/negate a)`, and `a - a` is `(g/sub a a)`.
+
+  a commutative group is also called an \"abelian group\"."
+  [opts generator type-name & {:keys [commutative?]}]
+  (additive-monoid opts generator type-name :commutative? commutative?)
+  (additive-inverse opts generator type-name))
+
+(defn multiplicative-group
+  "A multiplicative group is a type `a` that passes all of the laws in
+  `multiplicative-monoid` (optionally commutative), and additionally can
+  generate a multiplicative inverse for every element. `g/invert` returns the
+  multiplicative inverse. The additional rules are:
+
+      a * (1 / a) == 1
+      (1 / a) * a == 1
+      a / a == 1
+
+  where `(1 / a)` is `(g/invert a)`, and `a / a` is `(g/div a a)`.
+
+  a commutative group is also called an \"abelian group\"."
+  [opts generator type-name & {:keys [commutative?]}]
+  (multiplicative-monoid opts generator type-name :commutative? commutative?)
+  (multiplicative-inverse opts generator type-name))
+
+(defn ring
+  "A ring is a type `a` that:
+
+  - passes all of the laws in `additive-group` with `:commutative? true`
+  - passes `multiplicative-semigroup`
+
+  and additionally can distribute its `g/mul` implementation over `g/add` on the
+  right or the left of a sum:
+
+      a * (b + c) == (a * b) + (a * c)
+      (b + c) * a == (b * a) + (c * a)
+
+  if `:with-unity? true` is passed, `ring` will check that `a`'s `g/mul`
+  implementation has an identity, ie, that `a` is a multiplicative monoid, not
+  just a multiplicative semigroup. A type with this structure is called a \"ring
+  with unity\".
+
+  If `:commutative? true` is passed, `ring` will check that `a` has a
+  commutative `g/mul` implementation; ie, that `a` is a \"commutative ring\". "
+  [opts generator type-name & {:keys [with-unity? commutative?]}]
+  (let [mul-check (if with-unity?
+                    multiplicative-monoid
+                    multiplicative-semigroup)]
+    (additive-group opts generator type-name :commutative? true))
+  (multiplicative-semigroup opts generator type-name :commutative? commutative?))
+
+(defn field
+  "A field is a type `a` that:
+
+  - passes all of the laws in `additive-group` with `:commutative? true`
+  - passes `multiplicative-group` with `:commutative? true`
+
+  and additionally can distribute its `g/mul` implementation over `g/add` on the
+  right or the left of a sum:
+
+      a * (b + c) == (a * b) + (a * c)
+      (b + c) * a == (b * a) + (c * a)
+
+  if `:skew? true` is passed, `field` will drop the condition that the `g/mul`
+  implementation is commutative.
+
+  A type `a` with this structure is called a \"skew field\", or \"division
+  ring\"."
+  [opts generator type-name & {:keys [skew?]}]
+  (additive-group opts generator type-name :commutative? true)
+  (multiplicative-group opts generator type-name :commutative? (not skew?))
+  (mul-distributes-over-add opts generator type-name))

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -19,6 +19,7 @@
 
 (ns sicmutils.numbers-test
   (:require [clojure.test :refer [is deftest testing]]
+            [same :refer [with-comparator]]
             [sicmutils.complex :as c]
             [sicmutils.util :as u]
             [sicmutils.generic :as g]
@@ -46,8 +47,9 @@
 
 (deftest floating-point-laws
   ;; Doubles form a field too.
-  (l/field 100 (sg/reasonable-double) #?(:clj  "java.lang.Double"
-                                         :cljs "floating point js/Number")))
+  (with-comparator (v/within 1e-3)
+    (l/field 100 (sg/reasonable-double) #?(:clj  "java.lang.Double"
+                                           :cljs "floating point js/Number"))))
 
 (deftest number-generics
   (gt/integral-tests identity :exclusions #{:exact-divide})

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -32,9 +32,9 @@
 
 (deftest numeric-laws
   ;; All native types available on clj and cljs form fields.
-  (l/field 100 sg/bigint #?(:clj "clojure.lang.BigInt" :cljs "js/BigInt"))
-  (l/field 100 sg/long #?(:clj "java.lang.Long" :cljs "goog.math.Long"))
-  (l/field 100 sg/integer #?(:clj "java.lang.Integer" :cljs "goog.math.Integer"))
+  (l/ring 100 sg/bigint #?(:clj "clojure.lang.BigInt" :cljs "js/BigInt"))
+  (l/ring 100 sg/long #?(:clj "java.lang.Long" :cljs "goog.math.Long"))
+  (l/ring 100 sg/integer #?(:clj "java.lang.Integer" :cljs "goog.math.Integer"))
 
   #?(:clj
      ;; There's no biginteger / bigint distinction in cljs.
@@ -42,7 +42,7 @@
 
   #?(:cljs
      ;; this is covered by sg/long in clj.
-     (l/field 100 sg/native-integral "integral js/Number")))
+     (l/ring 100 sg/native-integral "integral js/Number")))
 
 (deftest floating-point-laws
   ;; Doubles form a field too.

--- a/test/sicmutils/value_test.cljc
+++ b/test/sicmutils/value_test.cljc
@@ -19,10 +19,24 @@
 
 (ns sicmutils.value-test
   (:require [clojure.test :refer [is deftest testing]]
+            #?(:cljs [cljs.reader :refer [read-string]])
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
      (:import (clojure.lang PersistentVector))))
+
+(deftest bigint-literal
+  (testing "u/parse-bigint can round-trip Bigint instances in clj or cljs. "
+    (is (= #?(:clj 10N
+              :cljs '(sicmutils.util/bigint 10))
+           (read-string {:readers {'sicm/bigint u/parse-bigint}}
+                        (pr-str #sicm/bigint 10))))
+    (let [one-e-40 (apply str "1" (repeat 40 "0"))]
+      (is (= #?(:clj (bigint 1e40)
+                :cljs (list 'sicmutils.util/bigint one-e-40))
+             (read-string {:readers {'sicm/bigint u/parse-bigint}}
+                          (pr-str #sicm/bigint one-e-40)))
+          "Parsing #sicm/bigint works with big strings too."))))
 
 (deftest vector-value-impl
   (testing "nullity?"


### PR DESCRIPTION
This PR:

- adds a reader literal for `#sicm/bigint` parsing at the repl and in source
- adds `test.check` generators for many of the types we use.
- adds test.check tests for semigroup, monoid, group, ring and field, with a few variations on each. These are nice gut checks of the `g/add`, `g/mul`, `g/sub`, `g/negate` and `g/invert` implementations.