### PR TITLE
Add fraction.js, sicmutils.ratio for cross-platform ratio support (4)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,7 @@
                  [com.taoensso/timbre "4.11.0-alpha1"
                   :exclusions [org.clojure/clojurescript]]
                  [org.apache.commons/commons-math3 "3.6.1"]
+                 [org.clojars.sritchie09/bigfraction "4.0.12-0"]
                  [cljsjs/complex "2.0.11-0"]
                  [hiccup "1.0.5"]
                  [nrepl "0.7.0"]

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,2 +1,3 @@
 {sicm/complex sicmutils.complex/parse-complex
- sicm/bigint  sicmutils.util/parse-bigint}
+ sicm/bigint  sicmutils.util/parse-bigint
+ sicm/ratio   sicmutils.ratio/parse-ratio}

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -37,8 +37,7 @@
                            (g/- t0 (g/* q t)) t
                            (g/- r0 (g/* q r)) r))))))
 
-(defn gcd
-  [a b]
+(defn gcd [a b]
   (cond (v/nullity? a) (g/abs b)
         (v/nullity? b) (g/abs a)
         (not (and (v/integral? a) (v/integral? b))) 1

--- a/src/sicmutils/infix.cljc
+++ b/src/sicmutils/infix.cljc
@@ -23,7 +23,7 @@
             [clojure.string :as s]
             [pattern.rule :as R #?@(:cljs [:include-macros true])]
             [sicmutils.expression :as x]
-            [sicmutils.util :as u]
+            [sicmutils.ratio :as r]
             [sicmutils.numerical.compile :as compile]))
 
 (defn ^:private make-symbol-generator
@@ -286,8 +286,8 @@
       'sqrt #(str "\\sqrt " (maybe-brace (first %)))}
      :render-primitive
      (fn r [v]
-       (cond (u/ratio? v)
-             (str "\\frac" (brace (u/numerator v)) (brace (u/denominator v)))
+       (cond (r/ratio? v)
+             (str "\\frac" (brace (r/numerator v)) (brace (r/denominator v)))
 
              :else
              (let [s (str v)]

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -27,10 +27,10 @@
                            * core-times}
                   #?@(:cljs [:exclude [zero? / + - *]]))
   (:require [sicmutils.complex :refer [complex]]
+            [sicmutils.ratio :as r]
 
             ;; Required to enable the generic gcd implementation.
             [sicmutils.euclid]
-
             [sicmutils.generic :as g]
             [sicmutils.util :as u]
             [sicmutils.value :as v]
@@ -40,15 +40,18 @@
      (:import [clojure.lang BigInt Ratio]
               [java.math BigInteger])))
 
+;; "Backstop" implementations that apply to anything that descends from
+;; v/numtype.
 (defmethod g/add [v/numtype v/numtype] [a b] (#?(:clj +' :cljs core-plus) a b))
 (defmethod g/mul [v/numtype v/numtype] [a b] (#?(:clj *' :cljs core-times) a b))
 (defmethod g/sub [v/numtype v/numtype] [a b] (#?(:clj -' :cljs core-minus) a b))
 (defmethod g/negate [v/numtype] [a] (core-minus a))
-(defmethod g/div [v/numtype v/numtype] [a b] (core-div a b))
-(defmethod g/invert [v/numtype] [a] (core-div a))
+(defmethod g/negative? [v/numtype] [a] (neg? a))
 (defmethod g/expt [v/numtype v/numtype] [a b] (u/compute-expt a b))
 (defmethod g/abs [v/numtype] [a] (u/compute-abs a))
 (defmethod g/magnitude [v/numtype] [a] (u/compute-abs a))
+(defmethod g/div [v/numtype v/numtype] [a b] (core-div a b))
+(defmethod g/invert [v/numtype] [a] (core-div a))
 
 ;; trig operations
 (defmethod g/atan [v/numtype] [a] (Math/atan a))
@@ -114,7 +117,6 @@
   {:pre [(v/nullity? (g/remainder a b))]}
   (g/quotient a b))
 
-(defmethod g/negative? [::v/integral] [a] (neg? a))
 (defmethod g/exact-divide [::v/integral ::v/integral] [b a] (exact-divide b a))
 
 ;; All JVM and JS types that respond to ::native-integral behave correctly with
@@ -127,31 +129,20 @@
 ;; Clojure. The clojure methods are all slightly more refined based on Java's
 ;; type system.
 #?(:clj
-   (do (defmethod g/exact-divide [Ratio Ratio] [a b] (core-div a b))
-       (defmethod g/exact-divide [Ratio BigInt] [a b] (core-div a b))))
-
-#?(:clj
    ;; Efficient, native GCD on the JVM.
    (defmethod g/gcd [BigInteger BigInteger] [a b] (.gcd a b)))
 
 #?(:cljs
-   ;; TODO these are not defined on integral types, BUT we could get farther
-   ;; if we could convert these to a BigDecimal, once we support those.
-   (doseq [t [goog.math.Integer goog.math.Long js/BigInt]]
-     (defmethod g/div [t t] [a b]
-       (let [rem (g/remainder a b)]
-         (if (v/nullity? rem)
-           (g/quotient a b)
-           (u/arithmetic-ex
-            (str "Division between " a " and " b " is not exact.")))))
+   (do (defmethod g/div [::v/integral ::v/integral] [a b]
+         (let [rem (g/remainder a b)]
+           (if (v/nullity? rem)
+             (g/quotient a b)
+             (r/rationalize a b))))
 
-     (comment
-       ;; TODO invert is not defined on integral types, BUT we could get farther
-       ;; if we could convert these to a BigDecimal, once we support those.
-       ;;
-       ;; We could also make g/div above kick out the proper floating point ttype
-       ;; instead of throwing.
-       (defmethod g/invert [t] [a] (core-div a)))))
+       (defmethod g/invert [::v/integral] [a]
+         (if (v/unity? a)
+           a
+           (r/rationalize 1 a)))))
 
 ;; Clojurescript and Javascript have a number of numeric types available that
 ;; don't respond true to number? These each require their own block of method
@@ -184,12 +175,13 @@
      (defmethod g/magnitude [js/BigInt] [a b]
        (if (neg? a) (core-minus a) a))
 
-     ;; Compatibility between numbers and bigint.
-     (doseq [op [g/add g/mul g/sub g/gcd g/expt g/remainder g/quotient g/div]]
-       (defmethod op [js/BigInt ::v/native-integral] [a b]
+     ;; Compatibility between js/BigInt and the other integral types.
+     (doseq [op [g/add g/mul g/sub g/expt g/remainder g/quotient]]
+       (defmethod op [js/BigInt ::v/integral] [a b])
+       (defmethod op [js/BigInt ::v/integral] [a b]
          (op a (u/bigint b)))
 
-       (defmethod op [::v/native-integral js/BigInt] [a b]
+       (defmethod op [::v/integral js/BigInt] [a b]
          (op (u/bigint a) b)))
 
      ;; Google Closure library's 64-bit Long and arbitrary-precision Integer
@@ -206,7 +198,8 @@
 
        ;; Compatibility between basic number type and the google numeric types.
        ;; Any operation between a number and a Long or Integer will promote the
-       (doseq [op [g/add g/mul g/sub g/gcd g/expt g/remainder g/quotient g/div]]
+       ;; number.
+       (doseq [op [g/add g/mul g/sub g/expt g/remainder g/quotient]]
          (defmethod op [goog-type ::v/native-integral] [a b]
            (op a (.fromNumber goog-type b)))
 

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -25,7 +25,6 @@
             [sicmutils.expression :as x]
             [sicmutils.generic :as g]
             [sicmutils.numsymb :as sym]
-            [sicmutils.ratio :as r]
             [sicmutils.util :as u]
             [sicmutils.value :as v]
             #?(:cljs [goog.string :refer [format]])))

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -25,6 +25,7 @@
             [sicmutils.expression :as x]
             [sicmutils.generic :as g]
             [sicmutils.numsymb :as sym]
+            [sicmutils.ratio :as r]
             [sicmutils.util :as u]
             [sicmutils.value :as v]
             #?(:cljs [goog.string :refer [format]])))

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -155,7 +155,12 @@
            (.compare this (rationalize other))))
 
        Object
-       (toString [r] (str (v/freeze r)))
+       (toString [r]
+         (let [x (v/freeze r)]
+           (if number? x)
+           x
+           (let [[_ n d] x]
+             (str n "/" d))))
 
        IPrintWithWriter
        (-pr-writer [x writer opts]

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -188,6 +188,15 @@
 
    :cljs
    (do
+     (defn pow [r m]
+       (let [n (numerator r)
+             d (denominator r)]
+         (if (neg? m)
+           (rationalize (g/expt d (g/negate m))
+                        (g/expt n (g/negate m)))
+           (rationalize (g/expt n m)
+                        (g/expt d m)))))
+
      ;; The -equiv implementation handles equality with any number, so flip the
      ;; arguments around and invoke equiv.
      (defmethod v/eq [::v/number Fraction] [l r] (= r l))
@@ -206,11 +215,7 @@
      (defmethod g/magnitude [Fraction] [ a] (promote (.abs a)))
      (defmethod g/gcd [Fraction Fraction] [a b] (promote (.gcd a)))
      (defmethod g/lcm [Fraction Fraction] [a b] (promote (.lcm a)))
-     (defmethod g/expt [Fraction ::v/native-integral] [a b]
-       (promote (.pow a b)))
-
-     (defmethod g/expt [Fraction ::v/integral] [a b]
-       (promote (.pow a (js/Number b))))
+     (defmethod g/expt [Fraction ::v/integral] [a b] (pow a b))
 
      ;; Only integral ratios let us stay exact. If a ratio appears in the
      ;; exponent, convert the base to a number and call g/expt again.

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -206,9 +206,11 @@
      (defmethod g/magnitude [Fraction] [ a] (promote (.abs a)))
      (defmethod g/gcd [Fraction Fraction] [a b] (promote (.gcd a)))
      (defmethod g/lcm [Fraction Fraction] [a b] (promote (.lcm a)))
+     (defmethod g/expt [Fraction ::v/native-integral] [a b]
+       (promote (.pow a b)))
 
      (defmethod g/expt [Fraction ::v/integral] [a b]
-       (promote (.pow a b)))
+       (promote (.pow a (js/Number b))))
 
      ;; Only integral ratios let us stay exact. If a ratio appears in the
      ;; exponent, convert the base to a number and call g/expt again.
@@ -255,7 +257,6 @@
      ;; We handle the cases above where the exponent connects with integrals and
      ;; stays exact.
      (downcast-fraction g/expt)
-
      (doseq [op [g/add g/mul g/sub g/gcd g/remainder g/quotient g/div]]
        (upcast-number op)
        (downcast-fraction op))))

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -1,0 +1,234 @@
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.ratio
+  #?(:clj
+     (:refer-clojure :rename {rationalize core-rationalize
+                              ratio? core-ratio?
+                              denominator core-denominator
+                              numerator core-numerator}))
+  (:require [sicmutils.expression :as x]
+            [sicmutils.generic :as g]
+            [sicmutils.util :as u]
+            [sicmutils.value :as v]
+            #?(:cljs ["fraction.js/bigfraction.js" :as Fraction]))
+  #?(:clj (:import [clojure.lang BigInt Ratio])))
+
+(def ratiotype #?(:clj Ratio :cljs Fraction))
+(derive ratiotype ::v/number)
+
+(def ratio?
+  #?(:clj core-ratio?
+     :cljs (fn [r] (instance? Fraction r))))
+
+(def numerator
+  #?(:clj core-numerator
+     :cljs (fn [^Fraction x]
+             (if (pos? (.-s x))
+               (.-n x)
+               (- (.-n x))))))
+
+(def denominator
+  #?(:clj core-denominator
+     :cljs (fn [^Fraction x] (.-d x))))
+
+(defn rationalize
+  "Construct a ratio."
+  ([x]
+   #?(:cljs (if (v/integral? x)
+              x
+              (Fraction. x))
+      :clj (core-rationalize x)))
+  ([n d]
+   #?(:cljs (if (v/unity? d)
+              n
+              (Fraction. n d))
+      :clj (core-rationalize (/ n d)))))
+
+(defn parse-ratio
+  "TODO Experimental. Parser for the #sicm/frac data literal."
+  [x]
+  (cond #?@(:clj
+            [(ratio? x)
+             `(sicmutils.ratio/rationalize
+               ~(long (numerator x))
+               ~(long (denominator x)))])
+
+        (sequential? x)
+        (let [[op n d] x]
+          (cond (= op '/) `(sicmutils.ratio/rationalize ~n ~d)
+                (nil? d)  `(sicmutils.ratio/rationalize ~op ~n)
+                :else (u/illegal (str "Invalid: " x))))
+
+        (v/number? x) `(sicmutils.ratio/rationalize ~x)
+
+        :else (u/illegal (str "Invalid: " x))))
+
+#?(:clj
+   (extend-type Ratio
+     v/Value
+     (nullity? [c] (zero? c))
+     (unity? [c] (= 1 c))
+     (zero-like [_] 0)
+     (one-like [_] 1)
+     (freeze [x] (let [n (numerator x)
+                       d (denominator x)]
+                   (if (v/unity? d)
+                     n
+                     `(~'/ ~n ~d))))
+     (exact? [c] true)
+     (numerical? [_] true)
+     (kind [_] Ratio))
+
+   :cljs
+   (let [ZERO (Fraction. 0)
+         ONE  (Fraction. 1)]
+     (extend-type Fraction
+       v/Value
+       (nullity? [c] (.equals c ZERO))
+       (unity? [c] (.equals c ONE))
+       (zero-like [_] 0)
+       (one-like [_] 1)
+       (freeze [x] (let [n (numerator x)
+                         d (denominator x)]
+                     (if (v/unity? d)
+                       (js/Number n)
+                       `(~'/
+                         ~(js/Number n)
+                         ~(js/Number d)))))
+       (exact? [c] true)
+       (numerical? [_] true)
+       (kind [x] Fraction)
+
+       IEquiv
+       (-equiv [this other]
+         (cond (ratio? other) (.equals this other)
+
+               (v/integral? other)
+               (and (v/unity? (denominator this))
+                    (v/eq (numerator this) other))
+
+               ;; Enabling this would work, but would take us away from
+               ;; Clojure's behavior.
+               #_(v/number? other)
+               #_(.equals this (rationalize other))
+
+               :else false))
+
+       IComparable
+       (-compare [this other]
+         (if (or (number? other)
+                 (ratio? other))
+           (.compare this other)
+           (.compare this (rationalize other))))
+
+       Object
+       (toString [r] (str (v/freeze r)))
+
+       IPrintWithWriter
+       (-pr-writer [x writer opts]
+         (let [x (v/freeze x)]
+           (if (number? x)
+             (write-all writer x)
+             (write-all writer "#sicm/ratio " (str x))))))))
+
+#?(:clj
+   (doseq [[op f] [[g/exact-divide /]
+                   [g/quotient quot]
+                   [g/remainder rem]
+                   [g/modulo mod]]]
+     (defmethod op [Ratio Ratio] [a b] (f a b))
+     (defmethod op [Ratio ::v/integral] [a b] (f a b))
+     (defmethod op [::v/integral Ratio] [a b] (f a b)))
+
+   :cljs
+   (do
+     ;; The -equiv implementation handles equality with any number, so flip the
+     ;; arguments around and invoke equiv.
+     (defmethod v/eq [::v/number Fraction] [l r] (= r l))
+
+     (defn promote [x]
+       (if (v/unity? (denominator x))
+         (numerator x)
+         x))
+
+     (defmethod g/add [Fraction Fraction] [a b] (promote (.add a b)))
+     (defmethod g/sub [Fraction Fraction] [a b] (promote (.sub a b)))
+     (defmethod g/mul [Fraction Fraction] [a b] (promote (.mul a b)))
+     (defmethod g/div [Fraction Fraction] [a b] (promote (.div a b)))
+     (defmethod g/exact-divide [Fraction Fraction] [a b] (promote (.div a b)))
+
+     ;; TODO this does NOT work. We can actually only take integral exponents! To match Clojure, we want to:
+     ;;
+     ;; - handle integral exponents, just like the implementation allows.
+     ;; - if the pow is NOT integral, convert both toValue then proceed.
+     ;; - below, downcast fraction if we find it in the exponent.
+     ;; - from nt/expt, 'return an exact number if the base is an exact number
+     ;; - and the power is an integer, otherwise returns a double'
+
+     (defmethod g/expt [Fraction Fraction] [a b] (promote (.pow a b)))
+
+     (defmethod g/negate [Fraction] [a] (promote (.neg a)))
+     (defmethod g/negative? [Fraction] [a] (neg? (.-s a)))
+     (defmethod g/invert [Fraction] [a] (promote (.inverse a)))
+     (defmethod g/square [Fraction] [a] (promote (.mul a a)))
+     (defmethod g/cube [Fraction] [a] (promote (.pow a 3)))
+     (defmethod g/abs [Fraction] [a] (promote (.abs a)))
+     (defmethod g/magnitude [Fraction] [ a] (promote (.abs a)))
+     (defmethod g/gcd [Fraction Fraction] [a b] (promote (.gcd a)))
+     (defmethod g/lcm [Fraction Fraction] [a b] (promote (.lcm a)))
+
+     (defmethod g/quotient [Fraction Fraction] [a b]
+       (promote
+        (let [^Fraction x (.div a b)]
+          (if (pos? (.-s x))
+            (.floor x)
+            (.ceil x)))))
+
+     (defmethod g/remainder [Fraction Fraction] [a b]
+       (promote (.mod a b)))
+
+     ;; Cross-compatibility with numbers in CLJS.
+     (defn downcast-fraction
+       "Anything that `upcast-number` doesn't catch will hit this and pull a floating
+  point value out of the ratio."
+       [op]
+       (defmethod op [Fraction ::v/number] [a b]
+         (op (.valueOf a) b))
+
+       (defmethod op [::v/number Fraction] [a b]
+         (op a (.valueOf b))))
+
+     (defn upcast-number
+       "Integrals can stay exact, so they become ratios before op."
+       [op]
+       (defmethod op [Fraction ::v/integral] [a b]
+         (op a (Fraction. b 1)))
+
+       (defmethod op [::v/integral Fraction] [a b]
+         (op (Fraction. a 1) b)))
+
+     ;; An exact number should become a ratio rather than erroring out, if one
+     ;; side of the calculation is already rational (but not if neither side
+     ;; is).
+     (upcast-number g/exact-divide)
+
+     (doseq [op [g/add g/mul g/sub g/gcd g/expt g/remainder g/quotient g/div]]
+       (upcast-number op)
+       (downcast-fraction op))))

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -48,6 +48,11 @@
   #?(:clj core-denominator
      :cljs (fn [^Fraction x] (.-d x))))
 
+(defn ^:private promote [x]
+  (if (v/unity? (denominator x))
+    (numerator x)
+    x))
+
 (defn rationalize
   "Construct a ratio."
   ([x]
@@ -58,7 +63,7 @@
   ([n d]
    #?(:cljs (if (v/unity? d)
               n
-              (Fraction. n d))
+              (promote (Fraction. n d)))
       :clj (core-rationalize (/ n d)))))
 
 (def ^:private ratio-pattern #"([-+]?[0-9]+)/([0-9]+)")
@@ -186,11 +191,6 @@
      ;; The -equiv implementation handles equality with any number, so flip the
      ;; arguments around and invoke equiv.
      (defmethod v/eq [::v/number Fraction] [l r] (= r l))
-
-     (defn promote [x]
-       (if (v/unity? (denominator x))
-         (numerator x)
-         x))
 
      (defmethod g/add [Fraction Fraction] [a b] (promote (.add a b)))
      (defmethod g/sub [Fraction Fraction] [a b] (promote (.sub a b)))

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -27,9 +27,8 @@
             [sicmutils.polynomial :as p]
             [sicmutils.polynomial-gcd :as poly]
             [sicmutils.ratio :as r]
-            [sicmutils.value :as v])
-  #?(:clj
-     (:import [clojure.lang Ratio BigInt])))
+            [sicmutils.util :as u]
+            [sicmutils.value :as v]))
 
 (declare operator-table operators-known)
 
@@ -375,11 +374,8 @@
 (defmethod g/gcd [::v/integral ::p/polynomial] [a p]
   (poly/primitive-gcd (cons a (p/coefficients p))))
 
-#?(:clj
-   ;; Ratio support for Clojure.
-   (do
-     (defmethod g/gcd [::p/polynomial Ratio] [p a]
-       (poly/primitive-gcd (cons a (p/coefficients p))))
+(defmethod g/gcd [::p/polynomial r/ratiotype] [p a]
+  (poly/primitive-gcd (cons a (p/coefficients p))))
 
-     (defmethod g/gcd [Ratio ::p/polynomial] [a p]
-       (poly/primitive-gcd (cons a (p/coefficients p))))))
+(defmethod g/gcd [r/ratiotype ::p/polynomial] [a p]
+  (poly/primitive-gcd (cons a (p/coefficients p))))

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -26,7 +26,7 @@
             [sicmutils.numsymb :as sym]
             [sicmutils.polynomial :as p]
             [sicmutils.polynomial-gcd :as poly]
-            [sicmutils.util :as u]
+            [sicmutils.ratio :as r]
             [sicmutils.value :as v])
   #?(:clj
      (:import [clojure.lang Ratio BigInt])))
@@ -95,7 +95,7 @@
         cs (into (into #{} cv) (p/coefficients u))
         integerizing-factor (g/*
                              (if (< lcv 0) -1 1)
-                             (reduce g/lcm 1 (map u/denominator (filter u/ratio? cs))))
+                             (reduce g/lcm 1 (map r/denominator (filter r/ratio? cs))))
         u' (if (not (v/unity? integerizing-factor)) (p/map-coefficients #(g/* integerizing-factor %) u) u)
         v' (if (not (v/unity? integerizing-factor)) (p/map-coefficients #(g/* integerizing-factor %) v) v)
         g (poly/gcd u' v')
@@ -325,14 +325,12 @@
 (defmethod g/mul [::rational-function ::v/number] [r c]
   (make (g/mul (.-u r) c) (.-v r)))
 
-#?(:clj
-   ;; Ratio support for Clojure.
-   (do
-     (defmethod g/mul [::rational-function Ratio] [r a]
-       (make (g/mul (.-u r) (numerator a)) (g/mul (.-v r) (denominator a))))
+;; Ratio support for Clojure.
+(defmethod g/mul [::rational-function r/ratiotype] [r a]
+  (make (g/mul (.-u r) (r/numerator a)) (g/mul (.-v r) (r/denominator a))))
 
-     (defmethod g/mul [Ratio ::rational-function] [a r]
-       (make (g/mul (numerator a) (.-u r)) (g/mul (denominator a) (.-v r))))))
+(defmethod g/mul [r/ratiotype ::rational-function] [a r]
+  (make (g/mul (r/numerator a) (.-u r)) (g/mul (r/denominator a) (.-v r))))
 
 (defmethod g/div [::rational-function ::rational-function] [a b] (div a b))
 

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -272,7 +272,6 @@
 (defmethod g/add [::rational-function ::p/polynomial] [r p] (addp r p))
 (defmethod g/add [::p/polynomial ::rational-function] [p r] (addp r p))
 
-;; TODO can we consolidate these below?
 (defmethod g/add [::rational-function ::v/number] [a b]
   (addp a (p/make-constant (.-arity a) b)))
 

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -3,10 +3,7 @@
   (:refer-clojure :rename {bigint core-bigint
                            biginteger core-biginteger
                            int core-int
-                           long core-long
-                           #?@(:clj [ratio? core-ratio?
-                                     denominator core-denominator
-                                     numerator core-numerator])}
+                           long core-long}
                   #?@(:cljs [:exclude [bigint long int]]))
   (:require #?(:clj [clojure.math.numeric-tower :as nt])
             #?(:cljs goog.math.Integer)
@@ -50,21 +47,6 @@
 (defn bigint [x]
   #?(:clj (core-bigint x)
      :cljs (js/BigInt x)))
-
-(defn parse-bigint [x]
-  `(bigint ~x))
-
-(def ratio?
-  #?(:clj core-ratio?
-     :cljs (constantly false)))
-
-(def numerator
-  #?(:clj core-numerator
-     :cljs (fn [x] (throw (js/Error "Ratio doesn't exist in cljs.")))))
-
-(def denominator
-  #?(:clj core-denominator
-     :cljs (fn [x] (throw (js/Error "Ratio doesn't exist in cljs.")))))
 
 (defn biginteger [x]
   #?(:clj (core-biginteger x)

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -48,6 +48,9 @@
   #?(:clj (core-bigint x)
      :cljs (js/BigInt x)))
 
+(defn parse-bigint [x]
+  `(bigint ~x))
+
 (defn biginteger [x]
   #?(:clj (core-biginteger x)
      :cljs (js/BigInt x)))

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -9,7 +9,8 @@
             #?(:cljs goog.math.Integer)
             #?(:cljs goog.math.Long))
   #?(:clj
-     (:import [java.util.concurrent TimeUnit TimeoutException])))
+     (:import [clojure.lang BigInt]
+              [java.util.concurrent TimeUnit TimeoutException])))
 
 (defmacro import-def
   "import a single fn or var
@@ -41,6 +42,7 @@
 (def compute-sqrt #?(:clj nt/sqrt :cljs Math/sqrt))
 (def compute-expt #?(:clj nt/expt :cljs Math/pow))
 (def compute-abs #?(:clj nt/abs :cljs Math/abs))
+(def biginttype #?(:clj BigInt :cljs js/BigInt))
 (def inttype #?(:clj Integer :cljs goog.math.Integer))
 (def longtype #?(:clj Long :cljs goog.math.Long))
 

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -104,7 +104,7 @@
   (zero-like [_] 0)
   (one-like [_] 1)
   (freeze [x] x)
-  (exact? [x] (or (integer? x) (u/ratio? x)))
+  (exact? [x] (or (integer? x) #?(:clj (u/ratio? x))))
   (numerical? [_] true)
   (kind [x] #?(:clj (type x)
                :cljs (if (exact? x)
@@ -115,7 +115,9 @@
   (freeze [_] nil)
   (numerical? [_] false)
   (nullity? [_] true)
+  (zero-like [o] (u/unsupported "nil doesn't support zero-like."))
   (unity?[_] false)
+  (one-like [o] (u/unsupported "nil doesn't support one-like."))
   (kind [_] nil)
 
   PersistentVector

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -104,7 +104,7 @@
   (zero-like [_] 0)
   (one-like [_] 1)
   (freeze [x] x)
-  (exact? [x] (or (integer? x) #?(:clj (u/ratio? x))))
+  (exact? [x] (or (integer? x) #?(:clj (ratio? x))))
   (numerical? [_] true)
   (kind [x] #?(:clj (type x)
                :cljs (if (exact? x)

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -155,7 +155,7 @@
 
 ;; These two constitute the default cases.
 (defmethod eq [::number ::number] [l r]
-  #?(:clj (= l r)
+  #?(:clj  (= l r)
      :cljs (identical? l r)))
 
 (defmethod eq :default [l r]
@@ -178,8 +178,8 @@
                           [::native-integral goog.math.Long u/long]
                           [goog.math.Long js/BigInt u/bigint]
                           [goog.math.Integer js/BigInt u/bigint]]]
-       (defmethod eq [from to] [l r] (eq (f l) r))
-       (defmethod eq [to from] [l r] (eq l (f r))))
+       (defmethod eq [from to] [l r] (= (f l) r))
+       (defmethod eq [to from] [l r] (= l (f r))))
 
      (extend-protocol IEquiv
        number

--- a/test/sicmutils/calculus/vector_field_test.cljc
+++ b/test/sicmutils/calculus/vector_field_test.cljc
@@ -47,16 +47,20 @@
              (g/simplify ((v (m/chart R2-rect)) p))))
       (is (= ::vf/vector-field (v/kind v)))))
 
-  ;; TODO enable ratio literals for cljs.
-  #?(:clj
-     (testing "exponential"
-       (let-coordinates [[x y] R2-rect]
-         (let [circular (- (* x d:dy) (* y d:dx))]
-           (is (= '(up (+ (* -1/720 (expt a 6)) (* 1/24 (expt a 4)) (* -1/2 (expt a 2)) 1)
-                       (+ (* 1/120 (expt a 5)) (* -1/6 (expt a 3)) a))
-                  (g/simplify
-                   ((((vf/evolution 6) 'a circular) (m/chart R2-rect))
-                    ((m/point R2-rect) (up 1 0))))))))))
+  (testing "exponential"
+    (let-coordinates [[x y] R2-rect]
+      (let [circular (- (* x d:dy) (* y d:dx))]
+        (is (= '(up (+ (* (/ -1 720) (expt a 6))
+                       (* (/ 1 24) (expt a 4))
+                       (* (/ -1 2) (expt a 2))
+                       1)
+                    (+ (* (/ 1 120) (expt a 5))
+                       (* (/ -1 6) (expt a 3))
+                       a))
+               (v/freeze
+                (g/simplify
+                 ((((vf/evolution 6) 'a circular) (m/chart R2-rect))
+                  ((m/point R2-rect) (up 1 0))))))))))
 
   (testing "naming"
     (let-coordinates [[x y] R2-rect]

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -194,4 +194,4 @@
 
     ;; This looks awkward in cljs due to the ratio literal.
     (is (near (c/angle (c/complex 3 4))
-              (g/atan #?(:clj 4/3 :cljs (/ 4 3)))))))
+              (g/atan #sicm/ratio 4/3)))))

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -20,8 +20,6 @@
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]
             #?(:cljs [cljs.reader :refer [read-string]])
-            [same :refer [with-comparator]]
-            [same.compare :as sc]
             [sicmutils.numbers]
             [sicmutils.complex :as c]
             [sicmutils.generic :as g]
@@ -46,7 +44,7 @@
 (deftest complex-laws
   ;; Complex numbers form a field. We use a custom comparator to control some
   ;; precision loss.
-  (with-comparator (sc/compare-ulp 1.0 1e3)
+  (binding [sg/*complex-tolerance* 1e-3]
     (l/field 100 sg/complex "Complex")))
 
 (deftest value-protocol

--- a/test/sicmutils/examples/central_potential_test.cljc
+++ b/test/sicmutils/examples/central_potential_test.cljc
@@ -21,39 +21,30 @@
   (:refer-clojure :exclude [+ - * / partial])
   (:require [clojure.test :refer [deftest is testing]]
             [sicmutils.env :as e :refer [up + - * / partial]]
-            [sicmutils.examples.central-potential :as central]))
+            [sicmutils.examples.central-potential :as central]
+            [sicmutils.value :as v]))
 
 (deftest equations
   (e/with-literal-functions
     [m M x y X Y]
     (let [state (up 't (up 'x 'y 'X 'Y) (up 'dx 'dy 'dX 'dY))]
-      (is (= '(+ (* #?(:clj 1/2 :cljs 0.5) (expt dX 2) m2)
-                 (* #?(:clj 1/2 :cljs 0.5) (expt dY 2) m2)
-                 (* #?(:clj 1/2 :cljs 0.5) (expt dx 2) m1)
-                 (* #?(:clj 1/2 :cljs 0.5) (expt dy 2) m1))
-             (e/simplify ((central/T 'm1 'm2) state))))
+      (is (= '(+ (* (/ 1 2) (expt dX 2) m2)
+                 (* (/ 1 2) (expt dY 2) m2)
+                 (* (/ 1 2) (expt dx 2) m1)
+                 (* (/ 1 2) (expt dy 2) m1))
+             (v/freeze
+              (e/simplify ((central/T 'm1 'm2) state)))))
       ;; NB: teach simplifier to recognize difference of squares below
       (is (= '(/ (* -1 m1 m2)
                  (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
              (e/simplify ((central/V 'm1 'm2) state))))
       ;; (is (println "unsimplified central" ((central/L 'm1 'm2) state)))
-      (is (= #?(:clj
-                '(/ (+ (* (expt dX 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* (expt dY 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* (expt dx 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* (expt dy 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* 2 m1 m2))
-                    (* 2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2)))))
-
-                :cljs
-                ;; TODO CLJS can't handle ratios yet, so we can't simplify this
-                ;; 0.5 out.
-                '(/ (+ (* 0.5 (expt dX 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* 0.5 (expt dY 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* 0.5 (expt dx 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* 0.5 (expt dy 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
-                       (* m1 m2))
-                    (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2)))))
+      (is (= '(/ (+ (* (expt dX 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
+                    (* (expt dY 2) m2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
+                    (* (expt dx 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
+                    (* (expt dy 2) m1 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2))))
+                    (* 2 m1 m2))
+                 (* 2 (sqrt (+ (expt X 2) (* -2 X x) (expt Y 2) (* -2 Y y) (expt x 2) (expt y 2)))))
              (e/simplify ((central/L 'm1 'm2) state))))
       (let [F ((partial 1) (central/L 'm1 'm2))
             P ((partial 2) (central/L 'm1 'm2))
@@ -140,19 +131,20 @@
                     (up 0 0 0 (/ 1 m2)))
                (e/simplify (/ (A state))))))
       (is (= '(down (down (up (up (* m (((expt D 2) x) t))
-                                  (* #?(:clj 1/2 :cljs 0.5) m (((expt D 2) y) t)))
-                              (up (* #?(:clj 1/2 :cljs 0.5) m (((expt D 2) y) t))
+                                  (* (/ 1 2) m (((expt D 2) y) t)))
+                              (up (* (/ 1 2) m (((expt D 2) y) t))
                                   0))
                           (up (up 0
-                                  (* #?(:clj 1/2 :cljs 0.5) m (((expt D 2) x) t)))
-                              (up (* #?(:clj 1/2 :cljs 0.5) m (((expt D 2) x) t))
+                                  (* (/ 1 2) m (((expt D 2) x) t)))
+                              (up (* (/ 1 2) m (((expt D 2) x) t))
                                   (* m (((expt D 2) y) t)))))
                     (down (up (up 0 0)
                               (up 0 0))
                           (up (up 0 0)
                               (up 0 0))))
-             (e/simplify (((e/Lagrange-equations (central/L 'm 'M))
-                           (up (up x y) (up (constantly 0) (constantly 0)))) 't))))
+             (v/freeze
+              (e/simplify (((e/Lagrange-equations (central/L 'm 'M))
+                            (up (up x y) (up (constantly 0) (constantly 0)))) 't)))))
       (is (= '(up 1
                   (up dx dy dX dY)
                   (up (/ (+ (* M X) (* -1 M x))

--- a/test/sicmutils/examples/double_pendulum_test.cljc
+++ b/test/sicmutils/examples/double_pendulum_test.cljc
@@ -22,7 +22,8 @@
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
             [sicmutils.examples.double-pendulum :as double]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
-            [sicmutils.env :as e :refer [up down expt cos sin + - * /]]))
+            [sicmutils.env :as e :refer [up down expt cos sin + - * /]]
+            [sicmutils.value :as v]))
 
 (use-fixtures :once hermetic-simplify-fixture)
 
@@ -36,18 +37,20 @@
                (* -1 g l2 m2 (cos φ)))
            (e/simplify (V state))))
     (is (= '(+ (* l1 l2 m2 θdot φdot (cos (+ θ (* -1 φ))))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l1 2) m1 (expt θdot 2))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l1 2) m2 (expt θdot 2))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l2 2) m2 (expt φdot 2)))
-           (e/simplify (T state))))
+               (* (/ 1 2) (expt l1 2) m1 (expt θdot 2))
+               (* (/ 1 2) (expt l1 2) m2 (expt θdot 2))
+               (* (/ 1 2) (expt l2 2) m2 (expt φdot 2)))
+           (v/freeze
+            (e/simplify (T state)))))
     (is (= '(+ (* l1 l2 m2 θdot φdot (cos (+ θ (* -1 φ))))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l1 2) m1 (expt θdot 2))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l1 2) m2 (expt θdot 2))
-               (* #?(:clj 1/2 :cljs 0.5) (expt l2 2) m2 (expt φdot 2))
+               (* (/ 1 2) (expt l1 2) m1 (expt θdot 2))
+               (* (/ 1 2) (expt l1 2) m2 (expt θdot 2))
+               (* (/ 1 2) (expt l2 2) m2 (expt φdot 2))
                (* g l1 m1 (cos θ))
                (* g l1 m2 (cos θ))
                (* g l2 m2 (cos φ)))
-           (e/simplify (L state))))
+           (v/freeze
+            (e/simplify (L state)))))
     (e/with-literal-functions [θ φ]
       (is (= '(down (+ (* l1 l2 m2 (expt ((D φ) t) 2) (sin (+ (θ t) (* -1 (φ t)))))
                        (* l1 l2 m2 (((expt D 2) φ) t) (cos (+ (θ t) (* -1 (φ t)))))

--- a/test/sicmutils/examples/pendulum_test.cljc
+++ b/test/sicmutils/examples/pendulum_test.cljc
@@ -21,11 +21,13 @@
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
             [sicmutils.env :refer [up simplify]]
             [sicmutils.examples.pendulum :as p]
-            [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
+            [sicmutils.simplify :refer [hermetic-simplify-fixture]]
+            [sicmutils.value :as v]))
 
 (use-fixtures :once hermetic-simplify-fixture)
 
 (deftest simple-pendulum
-  (is (= '(+ (* #?(:clj 1/2 :cljs 0.5) (expt l 2) m (expt thetadot 2))
+  (is (= '(+ (* (/ 1 2) (expt l 2) m (expt thetadot 2))
              (* g l m (cos theta)))
-         (simplify ((p/L 'm 'l 'g (fn [_t] (up 0 0))) (up 't 'theta 'thetadot))))))
+         (v/freeze
+          (simplify ((p/L 'm 'l 'g (fn [_t] (up 0 0))) (up 't 'theta 'thetadot)))))))

--- a/test/sicmutils/fdg/ch1_test.cljc
+++ b/test/sicmutils/fdg/ch1_test.cljc
@@ -24,7 +24,8 @@
                                          D simplify compose
                                          up down
                                          sin cos square]]
-            [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
+            [sicmutils.simplify :refer [hermetic-simplify-fixture]]
+            [sicmutils.value :as v]))
 
 (use-fixtures :once hermetic-simplify-fixture)
 
@@ -56,8 +57,9 @@
       ((L2 mass metric) ((point coordsys) x) (* e v)))))
 
 (deftest chapter-one
-  (is (= '(+ (* #?(:clj 1/2 :cljs 0.5) (expt R 2) m (expt phidot 2) (expt (sin theta) 2))
-             (* #?(:clj 1/2 :cljs 0.5) (expt R 2) m (expt thetadot 2)))
-         (simplify
-          ((Lsphere 'm 'R)
-           (up 't (up 'theta 'phi) (up 'thetadot 'phidot)))))))
+  (is (= '(+ (* (/ 1 2) (expt R 2) m (expt phidot 2) (expt (sin theta) 2))
+             (* (/ 1 2) (expt R 2) m (expt thetadot 2)))
+         (v/freeze
+          (simplify
+           ((Lsphere 'm 'R)
+            (up 't (up 'theta 'phi) (up 'thetadot 'phidot))))))))

--- a/test/sicmutils/fdg/ch3_test.cljc
+++ b/test/sicmutils/fdg/ch3_test.cljc
@@ -30,7 +30,8 @@
                                          point chart
                                          R2-rect R2-polar]
              #?@(:cljs [:include-macros true])]
-            [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
+            [sicmutils.simplify :refer [hermetic-simplify-fixture]]
+            [sicmutils.value :as v]))
 
 (use-fixtures :each hermetic-simplify-fixture)
 
@@ -70,32 +71,33 @@
              (((+ d:dx (* 2 d:dy)) (+ (square r) (* 3 x))) R2-rect-point)))))))
 
 (deftest section-3-3
-  #?(:clj
-     ;; TODO making this clj only until we have proper ratio support.
-     (e/let-coordinates
-      [[x y] R2-rect]
-      (let [circular (- (* x d:dy) (* y d:dx))]
-        (is (= '((up 1 0)
-                 (up 0 t)
-                 (up (* -1/2 (expt t 2)) 0)
-                 (up 0 (* -1/6 (expt t 3)))
-                 (up (* 1/24 (expt t 4)) 0)
-                 (up 0 (* 1/120 (expt t 5))))
-               (simplify
-                (take 6
-                      (seq
-                       (((exp (* 't circular)) (chart R2-rect))
-                        ((point R2-rect) (up 1 0))))))))
-        (is (= '(up
-                 (+
-                  (* -1/720 (expt delta-t 6))
-                  (* 1/24 (expt delta-t 4))
-                  (* -1/2 (expt delta-t 2))
-                  1)
-                 (+ (* 1/120 (expt delta-t 5)) (* -1/6 (expt delta-t 3)) delta-t))
-               (simplify
-                ((((e/evolution 6) 'delta-t circular) (chart R2-rect))
-                 ((point R2-rect) (up 1 0))))))))))
+  (e/let-coordinates
+   [[x y] R2-rect]
+   (let [circular (- (* x d:dy) (* y d:dx))]
+     (is (= '((up 1 0)
+              (up 0 t)
+              (up (* (/ -1 2) (expt t 2)) 0)
+              (up 0 (* (/ -1 6) (expt t 3)))
+              (up (* (/ 1 24) (expt t 4)) 0)
+              (up 0 (* (/ 1 120) (expt t 5))))
+            (v/freeze
+             (simplify
+              (take 6
+                    (seq
+                     (((exp (* 't circular)) (chart R2-rect))
+                      ((point R2-rect) (up 1 0)))))))))
+     (is (= '(up
+              (+ (* (/ -1 720) (expt delta-t 6))
+                 (* (/ 1 24) (expt delta-t 4))
+                 (* (/ -1 2) (expt delta-t 2))
+                 1)
+              (+ (* (/ 1 120) (expt delta-t 5))
+                 (* (/ -1 6) (expt delta-t 3))
+                 delta-t))
+            (v/freeze
+             (simplify
+              ((((e/evolution 6) 'delta-t circular) (chart R2-rect))
+               ((point R2-rect) (up 1 0))))))))))
 
 (deftest section-3-5
   (e/let-coordinates

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -159,7 +159,7 @@
       (is (= 4 (add2 2)))
       (is (= -4 ((g/- add2) 2)))
       (is (= 9 ((g/sqrt add2) 79)))
-      (is (= (/ 1 9) ((g/invert add2) 7)))
+      (is (= #sicm/ratio 1/9 ((g/invert add2) 7)))
       (is (= 1 (explog 1.0)))
       (is (near 99.0 (explog 99.0)))
       (is (near 20.08553692 ((g/exp add2) 1.0)))
@@ -193,7 +193,7 @@
         (is (= 7 (h)))
         (is (= -1 (k)))
         (is (= 12 (j)))
-        (is (= (/ 3 4) (q)))))
+        (is (= #sicm/ratio 3/4 (q)))))
 
     (testing "at least 0 arity"
       (let [add (fn [& xs] (reduce + 0 xs))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -8,11 +8,8 @@
   (:require [clojure.test.check.generators :as gen]
             [same.ish :as si]
             [sicmutils.complex :as c]
-<<<<<<< HEAD
             [sicmutils.generic :as g]
-=======
             [sicmutils.ratio :as r]
->>>>>>> 77aa090... all ported
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -8,7 +8,11 @@
   (:require [clojure.test.check.generators :as gen]
             [same.ish :as si]
             [sicmutils.complex :as c]
+<<<<<<< HEAD
             [sicmutils.generic :as g]
+=======
+            [sicmutils.ratio :as r]
+>>>>>>> 77aa090... all ported
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
@@ -56,6 +60,14 @@
   (gen/let [r (reasonable-double)
             i (reasonable-double)]
     (c/complex r i)))
+
+(def ratio
+  (gen/let [n bigint
+            d bigint]
+    (let [d (if (v/nullity? d)
+              (u/bigint 1)
+              d)]
+      (r/rationalize n d))))
 
 (def ^:dynamic *complex-tolerance* 1e-12)
 

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -8,6 +8,7 @@
   (:require [clojure.test.check.generators :as gen]
             [same.ish :as si]
             [sicmutils.complex :as c]
+            [sicmutils.generic :as g]
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
@@ -56,6 +57,8 @@
             i (reasonable-double)]
     (c/complex r i)))
 
+(def ^:dynamic *complex-tolerance* 1e-12)
+
 (extend-protocol si/Approximate
   #?@(:cljs
       [js/BigInt
@@ -64,7 +67,5 @@
 
   #?(:cljs c/complextype :clj Complex)
   (ish [this that]
-    (and (si/ish (c/real-part this)
-                 (c/real-part that))
-         (si/ish (c/imag-part this)
-                 (c/imag-part that)))))
+    (< (g/abs (g/- this that))
+       *complex-tolerance*)))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -53,6 +53,12 @@
                                :min excluded-upper
                                :max max})])))
 
+(def any-integral
+  (gen/one-of [native-integral
+               bigint
+               long
+               integer]))
+
 (def complex
   (gen/let [r (reasonable-double)
             i (reasonable-double)]

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -59,6 +59,13 @@
     (c/complex r i)))
 
 (def ratio
+  "Generates a small ratio (or integer) using gen/small-integer. Shrinks
+  toward simpler ratios, which may be larger or smaller."
+  (gen/fmap
+   (fn [[a b]] (r/rationalize a b))
+   (gen/tuple gen/small-integer (gen/fmap inc gen/nat))))
+
+(def big-ratio
   (gen/let [n bigint
             d bigint]
     (let [d (if (v/nullity? d)

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -20,7 +20,11 @@
 (ns sicmutils.generic-test
   (:refer-clojure :exclude [+ - * / zero?])
   (:require [clojure.test :refer [is deftest testing]]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]
+             #?@(:cljs [:include-macros true])]
             [sicmutils.generic :as g]
+            [sicmutils.laws :as l]
             [sicmutils.value :as v]))
 
 (defmulti s* v/argument-kind)
@@ -54,8 +58,7 @@
     (is (= "eceoeleienrcrorlrirnicioiliiinncnonlninn" (s* "erin" "colin"))))
   (testing "add"
     (is (= "foobar" (s+ "foo" "bar")))
-    (is (= "zzz" (s+ "" "zzz")))
-    ))
+    (is (= "zzz" (s+ "" "zzz")))))
 
 (deftest type-assigner
   (testing "types"
@@ -65,25 +68,43 @@
 
 (deftest generic-plus
   (is (= 0 (g/+)) "no args returns additive identity")
-  (is (= 3.14 (g/+ 3.14)) "single arg should return itself")
-  (is (= 10 (g/+ 0 10 0.0 0 0)) "multi-arg works, as long as zeros appear.")
-  (is (= "happy" (g/+ 0 "happy" 0.0 0 0)) "returns really anything."))
+  (checking "g/+"
+            100
+            [x gen/any]
+            (is (= x (g/+ x)) "single arg should return itself, for any type.")
+            (is (= (if (v/nullity? x) 0 x)
+                   (g/+ x 0))
+                "adding a 0 works for any input. The first zero element gets
+                returned.")
+            (is (= x (g/+ 0 x)) "adding a leading 0 acts as identity.")
+            (is (= (if (v/nullity? x) 0 x)
+                   (g/+ 0 x 0.0 0 0)) "multi-arg works as long as zeros
+            appear.")))
 
 (deftest generic-minus
   (is (= 0 (g/-)) "no-arity returns the additive identity.")
-  (is (= 10 (g/- 10 0)) "Subtracting a zero works, with no implementations registered.")
-  (is (= "face" (g/- "face" 0))))
+  (checking "Subtracting a zero acts as id, with no implementations registered."
+            100
+            [x gen/any]
+            (is (= x (g/- x 0)))))
 
 (deftest generic-times
   (is (= 1 (g/*)) "No args returns the multiplicative identity.")
-  (is (= 2 (g/* 2)) "single arg returns itself.")
-  (is (= 5 (g/* 5 1) (g/* 1 5)) "Anything times a 1 returns itself.")
-  (is (= "face" (g/* "face" 1) (g/* 1 "face")) "works for really anything."))
+  (checking "g/*"
+            100
+            [x gen/any]
+            (is (= x (g/* x)) "single arg returns itself.")
+            (is (= (if (v/unity? x) 1 x)
+                   (g/* x 1)) "First unity gets returned.")
+            (is (= x (g/* 1 x)) "Anything times a 1 returns itself.")))
 
 (deftest generic-divide
   (is (= 1 (g/divide)) "division with no args returns multiplicative identity")
-  (is (= 20 (g/divide 20 1)) "dividing by one a single time returns the input")
-  (is (= "face" (g/divide "face" 1 1 1 1.0 1)) "dividing by 1 returns the input"))
+  (checking "g/divide"
+            100
+            [x gen/any]
+            (is (= x (g/divide x 1)) "dividing by one a single time returns the input")
+            (is (= x (g/divide x 1 1 1 1.0 1)) "dividing by 1 returns the input")))
 
 (defn ^:private is* [eq actual expected]
   (is (eq actual expected)

--- a/test/sicmutils/infix_test.cljc
+++ b/test/sicmutils/infix_test.cljc
@@ -140,7 +140,7 @@
          (s->JS (+ (sin 'x) (expt (sin 'x) 2)))))
   (is (= (str "function(x, dx) {\n"
               "  var t1 = Math.sin(x);\n"
-              "  return " #?(:clj "-1/2" :cljs "-0.5") " * Math.pow(dx, 2) * t1 + dx * Math.cos(x) + t1;\n"
+              "  return -1/2 * Math.pow(dx, 2) * t1 + dx * Math.cos(x) + t1;\n"
               "}")
          (s->JS (reduce + (take 3 (taylor-series-terms sin 'x 'dx)))
                 :symbol-generator (make-symbol-generator "t")
@@ -233,25 +233,18 @@
                        (up 'x 'y)
                        (up 'dx 'dy))
                       (take 3)
-                      (reduce +))
-            half #?(:clj "1/2" :cljs "0.5")
-            tex-half #?(:clj "\\frac{1}{2}" :cljs "0.5")]
-        (is (= (format "%s dx² ∂₀(∂₀f)(up(x, y)) + dx dy ∂₁(∂₀f)(up(x, y)) + %s dy² ∂₁(∂₁f)(up(x, y)) + dx ∂₀f(up(x, y)) + dy ∂₁f(up(x, y)) + f(up(x, y))" half half)
+                      (reduce +))]
+        (is (= "1/2 dx² ∂₀(∂₀f)(up(x, y)) + dx dy ∂₁(∂₀f)(up(x, y)) + 1/2 dy² ∂₁(∂₁f)(up(x, y)) + dx ∂₀f(up(x, y)) + dy ∂₁f(up(x, y)) + f(up(x, y))"
                (s->infix expr)))
 
-        ;; TODO once we get fractional support, render fractions correctly. Or,
-        ;; since cljs *is* js, consider doing something different here.
-        (is (= (format
-                (str "function(dx, dy, f, partial, x, y) {\n"
-                     "  var _0003 = partial(0);\n"
-                     "  var _0004 = partial(1);\n"
-                     "  var _0005 = [x, y];\n"
-                     "  var _0006 = _0003(f);\n"
-                     "  var _0007 = _0004(f);\n"
-                     "  return %s * Math.pow(dx, 2) * _0003(_0006)(_0005) + dx * dy * _0004(_0006)(_0005) + %s * Math.pow(dy, 2) * _0004(_0007)(_0005) + dx * _0006(_0005) + dy * _0007(_0005) + f(_0005);\n}")
-                half half)
+        (is (= (str "function(dx, dy, f, partial, x, y) {\n"
+                    "  var _0003 = partial(0);\n"
+                    "  var _0004 = partial(1);\n"
+                    "  var _0005 = [x, y];\n"
+                    "  var _0006 = _0003(f);\n"
+                    "  var _0007 = _0004(f);\n"
+                    "  return 1/2 * Math.pow(dx, 2) * _0003(_0006)(_0005) + dx * dy * _0004(_0006)(_0005) + 1/2 * Math.pow(dy, 2) * _0004(_0007)(_0005) + dx * _0006(_0005) + dy * _0007(_0005) + f(_0005);\n}")
                (s->JS expr :deterministic? true)))
 
-        (is (= (format "%s\\,{dx}^{2}\\,\\partial_0\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,dy\\,\\partial_1\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + %s\\,{dy}^{2}\\,\\partial_1\\left(\\partial_1f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,\\partial_0f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dy\\,\\partial_1f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right)"
-                       tex-half tex-half)
+        (is (= "\\frac{1}{2}\\,{dx}^{2}\\,\\partial_0\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,dy\\,\\partial_1\\left(\\partial_0f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + \\frac{1}{2}\\,{dy}^{2}\\,\\partial_1\\left(\\partial_1f\\right)\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dx\\,\\partial_0f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + dy\\,\\partial_1f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right) + f\\left(\\begin{pmatrix}x\\\\y\\end{pmatrix}\\right)"
                (s->TeX expr)))))))

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -42,13 +42,16 @@
                 (((expt D 2) q) t)
                 (((expt D 3) q) t))
            (g/simplify ((L/Gamma q 5) 't))))
-    (is (= '(+ (* #?(:clj 1/2 :cljs 0.5) (expt t 2) (((expt D 2) q) t))
+
+    (is (= '(+ (* (/ 1 2) (expt t 2) (((expt D 2) q) t))
                (* -1 t t1 (((expt D 2) q) t))
-               (* #?(:clj 1/2 :cljs 0.5) (expt t1 2) (((expt D 2) q) t))
+               (* (/ 1 2) (expt t1 2) (((expt D 2) q) t))
                (* -1 t ((D q) t))
                (* t1 ((D q) t))
                (q t))
-           (g/simplify ((L/osculating-path ((L/Γ q 4) 't)) 't1))))
+           (v/freeze
+            (g/simplify ((L/osculating-path ((L/Γ q 4) 't)) 't1)))))
+
     (is (= '(up t (up t (x t) (y t)) (up 1 ((D x) t) ((D y) t)))
            (g/simplify
             (f/with-literal-functions [x y]

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -113,24 +113,6 @@
                      :exclusions #{:exact-divide :gcd :remainder :modulo :quotient})
   (gt/floating-point-tests double :eq near))
 
-#?(:clj
-   (deftest ratio-generics
-     (testing "rational generics"
-       (gt/floating-point-tests
-        rationalize :eq #(= (rationalize %1)
-                            (rationalize %2))))
-
-     (testing "ratio-operations"
-       (is (= 13/40 (g/add 1/5 1/8)))
-       (is (= 1/8 (g/sub 3/8 1/4)))
-       (is (= 5/4 (g/div 5 4)))
-       (is (thrown? IllegalArgumentException (g/exact-divide 10/2 2/10)))
-       (is (= 1 (g/exact-divide 2/10 2/10)))
-       (is (= 1/2 (g/div 1 2)))
-       (is (= 1/4 (reduce g/div [1 2 2])))
-       (is (= 1/8 (reduce g/div [1 2 2 2])))
-       (is (= 1/8 (g/invert 8))))))
-
 (deftest arithmetic
   (testing "trig"
     (is (near (/ Math/PI 4) (g/asin (/ (g/sqrt 2) 2))))
@@ -196,12 +178,3 @@
   "numbers provides implementations, so test behaviors."
   (is (= 5 (g/divide 20 4)))
   (is (= 2 (g/divide 8 2 2))))
-
-#?(:clj
-   (deftest with-ratios
-     (is (= 13/40 (g/+ 1/5 1/8)))
-     (is (= 1/8 (g/- 3/8 1/4)))
-     (is (= 5/4 (g/divide 5 4)))
-     (is (= 1/2 (g/divide 1 2)))
-     (is (= 1/4 (g/divide 1 2 2)))
-     (is (= 1/8 (g/divide 1 2 2 2)))))

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -1,21 +1,21 @@
-;
-; Copyright © 2017 Colin Smith.
-; This work is based on the Scmutils system of MIT/GNU Scheme:
-; Copyright © 2002 Massachusetts Institute of Technology
-;
-; This is free software;  you can redistribute it and/or modify
-; it under the terms of the GNU General Public License as published by
-; the Free Software Foundation; either version 3 of the License, or (at
-; your option) any later version.
-;
-; This software is distributed in the hope that it will be useful, but
-; WITHOUT ANY WARRANTY; without even the implied warranty of
-; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-; General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License
-; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
 
 (ns sicmutils.numbers-test
   (:require [clojure.test :refer [is deftest testing]]
@@ -59,6 +59,9 @@
     (is (c/complex? (g/log -10)))
     (is (= (c/complex 0 Math/PI) (g/log -1))))
 
+  (testing "expt goes rational with negative expt"
+    (is (= #sicm/ratio 1/4 (g/expt 2 -2))))
+
   (testing "exp/log preserve exactness together"
     (is (= 0 (g/log (g/exp 0)))))
 
@@ -94,16 +97,28 @@
 
 (deftest integer-generics
   (gt/integral-tests u/int)
-  (gt/integral-a->b-tests u/int identity :exclusions #{:exact-divide}))
+  (gt/integral-a->b-tests u/int identity :exclusions #{:exact-divide})
+
+  (testing "g/expt"
+    (is (= (g/expt (u/int 2) (u/int -2))
+           (g/invert (u/int 4))))))
 
 (deftest long-generics
   (gt/integral-tests u/long)
-  (gt/integral-a->b-tests u/long identity :exclusions #{:exact-divide}))
+  (gt/integral-a->b-tests u/long identity :exclusions #{:exact-divide})
+
+  (testing "g/expt"
+    (is (= (g/expt (u/long 2) (u/long -2))
+           (g/invert (u/long 4))))))
 
 (deftest bigint-generics
   (gt/integral-tests u/bigint)
   (gt/integral-a->b-tests u/bigint identity)
-  (gt/integral-a->b-tests identity u/bigint))
+  (gt/integral-a->b-tests identity u/bigint)
+
+  (testing "g/expt"
+    (is (= (g/expt (u/bigint 2) (u/bigint -2))
+           (g/invert (u/bigint 4))))))
 
 #?(:clj
    (deftest biginteger-generics

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -32,9 +32,9 @@
 
 (deftest numeric-laws
   ;; All native types available on clj and cljs form fields.
-  (l/ring 100 sg/bigint #?(:clj "clojure.lang.BigInt" :cljs "js/BigInt"))
-  (l/ring 100 sg/long #?(:clj "java.lang.Long" :cljs "goog.math.Long"))
-  (l/ring 100 sg/integer #?(:clj "java.lang.Integer" :cljs "goog.math.Integer"))
+  (l/field 100 sg/bigint #?(:clj "clojure.lang.BigInt" :cljs "js/BigInt"))
+  (l/field 100 sg/long #?(:clj "java.lang.Long" :cljs "goog.math.Long"))
+  (l/field 100 sg/integer #?(:clj "java.lang.Integer" :cljs "goog.math.Integer"))
 
   #?(:clj
      ;; There's no biginteger / bigint distinction in cljs.
@@ -42,7 +42,7 @@
 
   #?(:cljs
      ;; this is covered by sg/long in clj.
-     (l/ring 100 sg/native-integral "integral js/Number")))
+     (l/field 100 sg/native-integral "integral js/Number")))
 
 (deftest floating-point-laws
   ;; Doubles form a field too.

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -77,7 +77,7 @@
     (is (= (p/make 3 [[[0 0 0] 1]]) (v/one-like (p/make 3 [[[1 2 1] 4] [[0 1 0] 5]]))))
     ;; we can't deduce the unit element from the zero polynomial over an
     ;; "unknown" ring
-    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+    (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
                  (v/one-like (p/make 2 [])))))
 
   (testing "add constant"

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -380,13 +380,10 @@
   (testing "specific test cases from generative tests"
     (let [p (p/make 4 [[[0 0 0 0] -2] [[1 6 3 3] 3]])
           q (p/make 4 [[[0 0 0 3] 3] [[4 0 6 2] 1]])
-          xs (map u/bigint [-2 3 -3 -3])]
+          xs [-2 3 -3 -3]]
       (is (= (g/mul (p/evaluate p xs)
                     (p/evaluate q xs))
-             (p/evaluate (g/mul p q) xs))
-          "This blows through non-bigint precision in cljs. bigint can promote
-          other types it interacts with, so any bigint in `xs` is enough to
-          maintain precision."))
+             (p/evaluate (g/mul p q) xs))))
 
     (let [p (p/make 5 [])
           q (p/make 5 [[[0 5 4 0 1] -2]
@@ -399,13 +396,9 @@
                        [[3 8 4 6 9] -8]
                        [[1 8 7 9 8] -2]])
           xs (map u/bigint [-9 7 0 9 -9])]
-      (is (= (u/bigint
-              (g/mul (p/evaluate p xs)
-                     (p/evaluate q xs)))
-             (u/bigint
-              (p/evaluate (g/mul p q) xs)))
-          "BigInt doesn't compare automatically with non-bigint, so make sure to
-          check that the results have the same type."))))
+      (is (= (g/mul (p/evaluate p xs)
+                    (p/evaluate q xs))
+             (p/evaluate (g/mul p q) xs))))))
 
 (deftest analyzer-test
   (let [new-analyzer (fn [] (a/make-analyzer
@@ -418,6 +411,7 @@
            (A '(* y (sin y) (cos (+ 1 (sin y) (sin y) (expt (sin y) 4)))))))
     (is (= '(+ (expt cos 2) (expt sin 2)) (A '(+ (expt cos 2) (expt sin 2)))))
     (is (= '(+ (expt cos 2) (expt sin 2)) (A '(+ (expt sin 2) (expt cos 2)))))
+
     (is (= '(+ (up (+ (/ d a) (/ (* -1 b) a))) (* -1 (up (/ (* -1 y) (+ a b)))))
            (A '(- (up (+ (/ d a)
                          (/ (- b) a)))
@@ -425,11 +419,9 @@
         "This test exploded without the doall that forces add-symbol! calls in
         analyze.clj.")
 
-    ;; Tests involving Ratio literals don't work in cljs yet.
-    #?(:clj
-       (do (is (= 'x (A '(* 1/2 (+ x x)))))
-           (is (= '(+ (* -1 m (expt ((D phi) t) 2) (r t)) (* m (((expt D 2) r) t)) ((D U) (r t)))
-                  (A '(- (* 1/2 m (+ (((expt D 2) r) t) (((expt D 2) r) t)))
-                         (+ (* 1/2 m (+ (* ((D phi) t) ((D phi) t) (r t))
-                                        (* ((D phi) t) ((D phi) t) (r t))))
-                            (* -1 ((D U) (r t))))))))))))
+    (is (= 'x (A '(* (/ 1 2) (+ x x)))))
+    (is (= '(+ (* -1 m (expt ((D phi) t) 2) (r t)) (* m (((expt D 2) r) t)) ((D U) (r t)))
+           (A '(- (* (/ 1 2) m (+ (((expt D 2) r) t) (((expt D 2) r) t)))
+                  (+ (* (/ 1 2) m (+ (* ((D phi) t) ((D phi) t) (r t))
+                                     (* ((D phi) t) ((D phi) t) (r t))))
+                     (* -1 ((D U) (r t))))))))))

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -78,6 +78,10 @@
         "Parsing #sicm/ratio works with big strings too.")))
 
 (deftest rationalize-test
+  (testing "r/rationalize promotes to bigint if evenly divisible"
+    (is (not (r/ratio? (r/rationalize 10 2))))
+    (is (r/ratio? (r/rationalize 10 3))))
+
   (checking "r/rationalize round-trips all integrals"
             100
             [x (gen/one-of [sg/any-integral sg/big-ratio])]

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -130,6 +130,8 @@
         "integral exponents stay exact")
 
     (is (= (-> #sicm/ratio 1/2 (g/expt (u/long 3)))
+           (-> #sicm/ratio 1/2 (g/expt (u/bigint 3)))
+           (-> #sicm/ratio 1/2 (g/expt (u/int 3)))
            #sicm/ratio 1/8)
         "different types work")
 

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -40,6 +40,7 @@
   )
 
 (deftest ratio-laws
+  ;; Rational numbers form a field!
   (l/field 100 sg/ratio "Ratio"))
 
 (deftest ratio-generics

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -41,7 +41,7 @@
 
 (deftest ratio-laws
   ;; Rational numbers form a field!
-  (l/field 100 sg/ratio "Ratio"))
+  (l/field 100 sg/big-ratio "Ratio"))
 
 (deftest ratio-generics
   (testing "rational generics"

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -93,12 +93,24 @@
                 "multiplying by denominator recovers numerator")
             (let [r      (r/rationalize n d)
                   factor (g/gcd n d)]
-              (is (= (g/abs d)
-                     (g/abs (g/mul factor (r/denominator r))))
-                  "denominator scales down by gcd")
-              (is (= (g/abs n)
-                     (g/abs (g/mul factor (r/numerator r))))
-                  "numerator scales down by gcd"))))
+              (when-not (r/ratio? r)
+                (is (= (g/abs d)
+                       (g/abs factor))
+                    "If rationalize doesn't return ratio the denominator must
+                    have been the gcd.")
+
+                (is (= (g/abs n)
+                       (g/abs (g/mul factor r)))
+                    "Recover the original n by multiplying the return value by
+                    the factor."))
+
+              (when (r/ratio? r)
+                (is (= (g/abs d)
+                       (g/abs (g/mul factor (r/denominator r))))
+                    "denominator scales down by gcd")
+                (is (= (g/abs n)
+                       (g/abs (g/mul factor (r/numerator r))))
+                    "numerator scales down by gcd")))))
 
 (deftest ratio-generics
   (testing "rational generics"

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -1,0 +1,79 @@
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.ratio-test
+  (:require [clojure.test :refer [is deftest testing]]
+            [sicmutils.ratio :as r]
+            [sicmutils.util :as u]
+            [sicmutils.generic :as g]
+            [sicmutils.generic-test :as gt]
+            [sicmutils.generators :as sg]
+            [sicmutils.laws :as l]
+            [sicmutils.value :as v]
+            [sicmutils.numbers :as n]))
+
+(deftest ratio-value-implementation
+  ;; TODO, test freeze!
+  ;;
+  ;; TODO exact-divide, quot, rem, all of the ops for the actual strangeness
+  ;; with these types.
+
+  ;; TODO fix tests changed by freeze.
+
+  ;; TODO ticket to fix equality, interop with complex numbers.
+  )
+
+(deftest ratio-laws
+  (l/field 100 sg/ratio "Ratio"))
+
+(deftest ratio-generics
+  (testing "rational generics"
+    (gt/integral-tests r/rationalize)
+    (gt/integral-a->b-tests r/rationalize identity)
+    (gt/floating-point-tests
+     r/rationalize :eq #(= (r/rationalize %1)
+                           (r/rationalize %2))))
+
+  (testing "ratio-operations"
+    (is (= #sicm/ratio 13/40
+           (g/add #sicm/ratio 1/5
+                  #sicm/ratio 1/8)))
+    (is (= #sicm/ratio 1/8
+           (g/sub #sicm/ratio 3/8
+                  #sicm/ratio 1/4)))
+
+    (is (= #sicm/ratio 5/4 (g/div 5 4)))
+    (is (= 25 (g/exact-divide #sicm/ratio 10/2
+                              #sicm/ratio 2/10)))
+    (is (= 1 (g/exact-divide #sicm/ratio 2/10
+                             #sicm/ratio 2/10)))
+    (is (= #sicm/ratio 1/2 (g/div 1 2)))
+    (is (= #sicm/ratio 1/4 (reduce g/div [1 2 2])))
+    (is (= #sicm/ratio 1/8 (reduce g/div [1 2 2 2])))
+    (is (= #sicm/ratio 1/8 (g/invert 8)))))
+
+(deftest with-ratio-literals
+  (is (= #sicm/ratio 13/40 (g/+ #sicm/ratio 1/5
+                                #sicm/ratio 1/8)))
+  (is (= #sicm/ratio 1/8 (g/- #sicm/ratio 3/8
+                              #sicm/ratio 1/4)))
+  (is (= #sicm/ratio 5/4 (g/divide 5 4)))
+  (is (= #sicm/ratio 1/2 (g/divide 1 2)))
+  (is (= #sicm/ratio 1/4 (g/divide 1 2 2)))
+  (is (= #sicm/ratio 1/8 (g/divide 1 2 2 2))))

--- a/test/sicmutils/rules_test.cljc
+++ b/test/sicmutils/rules_test.cljc
@@ -29,11 +29,8 @@
     (is (= '(sqrt (expt x 7)) (s '(sqrt (expt x 7)))))))
 
 (deftest divide-numbers-through-test
-  (let [d r/divide-numbers-through
-        ;; cljs doesn't support ratios.
-        one-half #?(:clj 1/2
-                    :cljs 0.5)]
-    (is (= one-half (d '(/ 1 2))))
+  (let [d r/divide-numbers-through]
+    (is (= #sicm/ratio 1/2 (d '(/ 1 2))))
     (is (= 'x (d '(* 1 x))))
     (is (= '(* x y z) (d '(* 1 x y z))))
     (is (= '(*) (d '(* 1))))

--- a/test/sicmutils/runner.cljs
+++ b/test/sicmutils/runner.cljs
@@ -56,6 +56,7 @@
             sicmutils.polynomial-test
             sicmutils.polynomial-gcd-test
             sicmutils.polynomial-factor-test
+            sicmutils.ratio-test
             sicmutils.numbers-test
             sicmutils.numsymb-test
             sicmutils.polynomial-test
@@ -127,6 +128,7 @@
            'sicmutils.polynomial-test
            'sicmutils.polynomial-gcd-test
            'sicmutils.polynomial-factor-test
+           'sicmutils.ratio-test
            'sicmutils.rational-function-test
            'sicmutils.rules-test
            'sicmutils.series-test

--- a/test/sicmutils/runner.cljs
+++ b/test/sicmutils/runner.cljs
@@ -103,14 +103,10 @@
 
            'sicmutils.sicm.ch1-test
            'sicmutils.sicm.ch2-test
+           'sicmutils.sicm.ch3-test
+           'sicmutils.sicm.ch5-test
+           'sicmutils.sicm.ch6-test
            'sicmutils.sicm.ch7-test
-
-           ;; TODO These don't currently work due to the lack of BigDecimal and
-           ;; proper rational numbers.
-
-           ;; 'sicmutils.sicm.ch3-test
-           ;; 'sicmutils.sicm.ch5-test
-           ;; 'sicmutils.sicm.ch6-test
 
            'sicmutils.analyzer-test
            'sicmutils.complex-test

--- a/test/sicmutils/series_test.cljc
+++ b/test/sicmutils/series_test.cljc
@@ -107,6 +107,8 @@
       (is (= '(1 2 3 4 5 6)
              (series/take 6 (series/partial-sums ones))))
 
-      #?(:clj
-         ;; Ratios, not compatible with cljs yet.
-         (is (= '(17/4 7/2 11/4 1) (series/take 4 (g/+ (g/* 1/4 nats) S))))))))
+      (is (= [#sicm/ratio 17/4
+              #sicm/ratio 7/2
+              #sicm/ratio 11/4
+              1]
+             (series/take 4 (g/+ (g/* #sicm/ratio 1/4 nats) S)))))))

--- a/test/sicmutils/sicm/ch2_test.cljc
+++ b/test/sicmutils/sicm/ch2_test.cljc
@@ -25,7 +25,8 @@
             [sicmutils.mechanics.rotation :refer [Euler->M]]
             [sicmutils.mechanics.rigid :as r]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
-            [sicmutils.util :as u]))
+            [sicmutils.util :as u]
+            [sicmutils.value :as v]))
 
 (use-fixtures :once hermetic-simplify-fixture)
 
@@ -111,9 +112,10 @@
                              (reduce max))))))))
 
 (deftest section-2-10
-  (is (= '(+ (* #?(:clj 1/2 :cljs 0.5) A (expt φdot 2) (expt (sin θ) 2))
-             (* #?(:clj 1/2 :cljs 0.5) C (expt φdot 2) (expt (cos θ) 2))
+  (is (= '(+ (* (/ 1 2) A (expt φdot 2) (expt (sin θ) 2))
+             (* (/ 1 2) C (expt φdot 2) (expt (cos θ) 2))
              (* C φdot ψdot (cos θ))
-             (* #?(:clj 1/2 :cljs 0.5) A (expt θdot 2))
-             (* #?(:clj 1/2 :cljs 0.5) C (expt ψdot 2)))
-         (simplify ((r/T-rigid-body 'A 'A 'C) Euler-state)))))
+             (* (/ 1 2) A (expt θdot 2))
+             (* (/ 1 2) C (expt ψdot 2)))
+         (v/freeze
+          (simplify ((r/T-rigid-body 'A 'A 'C) Euler-state))))))

--- a/test/sicmutils/sicm/ch3_test.cljc
+++ b/test/sicmutils/sicm/ch3_test.cljc
@@ -23,14 +23,15 @@
             [sicmutils.env :as e
              :refer [+ - * / D zero? partial simplify
                      up down
-                     literal-function]]
+                     literal-function]
+             #?@(:cljs [:include-macros true])]
             [sicmutils.mechanics.lagrange :as L]
             [sicmutils.mechanics.hamilton :as H]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.examples.driven-pendulum :as driven]
             [sicmutils.examples.top :as top]))
 
-(use-fixtures :once hermetic-simplify-fixture)
+(use-fixtures :each hermetic-simplify-fixture)
 
 (deftest section-3-1
   (testing "p.189"
@@ -135,13 +136,13 @@
                         0))
              (simplify (sysder top-state))))
       (is (= (str "function(A, C, gMR, p_phi, p_psi, p_theta, theta) {\n"
-                  "  var _0001 = Math.sin(theta);\n"
-                  "  var _0004 = Math.cos(theta);\n"
-                  "  var _0005 = Math.pow(_0004, 2);\n"
-                  "  var _0006 = Math.pow(_0001, 2);\n"
-                  "  return [1, [p_theta / A, (- p_psi * _0004 + p_phi) / (A * _0006), (A * p_psi * _0006 + C * p_psi * _0005 - C * p_phi * _0004) / (A * C * _0006)], [(A * gMR * Math.pow(_0004, 4) -2 * A * gMR * _0005 - p_phi * p_psi * _0005 + Math.pow(p_phi, 2) * _0004 + Math.pow(p_psi, 2) * _0004 + A * gMR - p_phi * p_psi) / (A * Math.pow(_0001, 3)), 0, 0]];\n"
+                  "  var _0001 = Math.cos(theta);\n"
+                  "  var _0004 = Math.sin(theta);\n"
+                  "  var _0005 = Math.pow(_0001, 2);\n"
+                  "  var _0006 = Math.pow(_0004, 2);\n"
+                  "  return [1, [p_theta / A, (- p_psi * _0001 + p_phi) / (A * _0006), (A * p_psi * _0006 + C * p_psi * _0005 - C * p_phi * _0001) / (A * C * _0006)], [(A * gMR * Math.pow(_0001, 4) -2 * A * gMR * _0005 - p_phi * p_psi * _0005 + Math.pow(p_phi, 2) * _0001 + Math.pow(p_psi, 2) * _0001 + A * gMR - p_phi * p_psi) / (A * Math.pow(_0004, 3)), 0, 0]];\n"
                   "}")
-             (-> top-state sysder simplify e/->JavaScript))))))
+             (-> top-state sysder simplify (e/->JavaScript :deterministic? true)))))))
 
 (deftest section-3-5
   (testing "p.221"
@@ -168,15 +169,15 @@
                         (* -1 g (expt l 2) m (sin theta)))
                      l))
              sysder))
-      ;; odd that we have _1 here when it's not used ... must be a bug in the CSE
-      ;; ah, we observe that _3 is omega*t, and we have a few examples of
-      ;; the sine (of that. So our algorithm is a little on the naive side o_o
+
+      ;; ah, we observe that _1 is omega*t, and we have a few examples of the
+      ;; sine (of that. So our algorithm is a little on the naive side o_o
       (is (= (str "function(a, g, l, m, omega, p_theta, t, theta) {\n"
-                  "  var _0002 = Math.pow(l, 2);\n"
-                  "  var _0003 = omega * t;\n"
-                  "  var _0004 = Math.sin(theta);\n"
-                  "  var _0005 = Math.cos(theta);\n"
-                  "  var _0006 = Math.sin(_0003);\n"
-                  "  return [1, (a * l * m * omega * _0006 * _0004 + p_theta) / (_0002 * m), (- Math.pow(a, 2) * l * m * Math.pow(omega, 2) * Math.pow(_0006, 2) * _0004 * _0005 - a * omega * p_theta * _0006 * _0005 - g * _0002 * m * _0004) / l];\n"
+                  "  var _0001 = omega * t;\n"
+                  "  var _0002 = Math.cos(theta);\n"
+                  "  var _0003 = Math.pow(l, 2);\n"
+                  "  var _0005 = Math.sin(theta);\n"
+                  "  var _0006 = Math.sin(_0001);\n"
+                  "  return [1, (a * l * m * omega * _0006 * _0005 + p_theta) / (_0003 * m), (- Math.pow(a, 2) * l * m * Math.pow(omega, 2) * Math.pow(_0006, 2) * _0005 * _0002 - a * omega * p_theta * _0006 * _0002 - g * _0003 * m * _0005) / l];\n"
                   "}")
-             (e/->JavaScript sysder))))))
+             (e/->JavaScript sysder :deterministic? true))))))

--- a/test/sicmutils/simplify_test.cljc
+++ b/test/sicmutils/simplify_test.cljc
@@ -68,10 +68,9 @@
   (is (= 'x (simplify-expression '(* 1 x))))
   (is (= '(* x y z) (simplify-expression '(* 1 x y z))))
   (is (= '(+ x y) (simplify-expression '(/ (* 2 (+ x y)) 2))))
-
-  (is (= #?(:clj  '(+ (* 1/2 x) (* 1/2 y))
-            :cljs '(+ (* 0.5 x) (* 0.5 y)))
-         (simplify-expression '(/ (+ x y) 2)))))
+  (is (= '(+ (* (/ 1 2) x) (* (/ 1 2) y))
+         (v/freeze
+          (simplify-expression '(/ (+ x y) 2))))))
 
 (deftest structures
   (let [A (m/by-rows [1 2] [3 4])

--- a/test/sicmutils/simplify_test.cljc
+++ b/test/sicmutils/simplify_test.cljc
@@ -51,7 +51,7 @@
 
 (deftest simplify-expressions
   (is (= 6 (simplify-expression '(* 1 2 3))))
-  (is (= #?(:clj 2/3 :cljs (/ 2 3))
+  (is (= #sicm/ratio 2/3
          (simplify-expression '(/ 2 3)))))
 
 (deftest trivial-simplifications


### PR DESCRIPTION
This PR:

- Adds a ratio implementation in CLJS, using a `js/BigInt` based version of `Fraction.js` that lives here: https://github.com/infusion/Fraction.js/blob/master/bigfraction.js
- adds a clojure reader literal, `#sicm/ratio "1/2"`, that parses these.
- Enables and fixes many tests that were special-cased for Clojurescript's lack of Ratio support. Woohoo!
- Upgrades numeric tests from `ring` to `field`
- Adds a general `g/div` and `g/invert` implementation to integral types that converts them to Ratios
- Fixes bad implementations of `g/expt`, which weren't correct in case of a negative exponent!