### PR TITLE
Custom column selection for tableau methods, fix for Richardson (integrals #1)

### DIFF
--- a/src/sicmutils/numerical/derivative.cljc
+++ b/src/sicmutils/numerical/derivative.cljc
@@ -195,7 +195,7 @@
 
 (defn central-difference-d2
   "Returns a single-variable function of a step size `h` that calculates the
-  backward-difference estimate of the second derivative of `f` at point `x`:
+  central-difference estimate of the second derivative of `f` at point `x`:
 
   f''(x) = [f(x + h) - 2f(x) + f(x - h)] / h^2
 

--- a/src/sicmutils/numerical/interpolate/polynomial.cljc
+++ b/src/sicmutils/numerical/interpolate/polynomial.cljc
@@ -252,7 +252,7 @@
 ;;
 ;; So define a function to grab that:
 
-(defn- first-terms [tableau]
+(defn first-terms [tableau]
   (map first tableau))
 
 ;; the final piece we need is a function that will extract the estimate from our
@@ -302,8 +302,10 @@
 ;; ## Generic Tableau Processing
 ;;
 ;; The above pattern, of processing tableau entries, is general enough that we
-;; can abstract it out into a higher order function that takes a `prepare`,
-;; `merge` and `present` function.
+;; can abstract it out into a higher order function that takes a `prepare` and
+;; `merge` function and generates a tableau. Any method generating a tableau can
+;; use a `present` function to extract the first row, OR to process the tableau
+;; in any other way that they like.
 ;;
 ;; This is necessarily more abstract! But we'll specialize it shortly, and
 ;; rebuild `neville-incremental` into its final form.
@@ -313,7 +315,7 @@
 ;; tableau-fn prepare merge present)`.
 
 (defn tableau-fn
-  "Returns the first row of a Newton-style approximation tableau, given:
+  "Returns a Newton-style approximation tableau, given:
 
   - `prepare`: a fn that processes each element of the supplied `points` into
   the state necessary to calculate future tableau entries.
@@ -329,23 +331,20 @@
   the inputs are of the same form returned by `prepare`. `merge` should return a
   new structure of the same form.
 
-  - `present`: a function of the entire first (lazy) row of the tableau. Use
-  `present` to drop extra aggregation information used in the course of
-  generating tableau entries.
-
   - `points`: the (potentially lazy) sequence of points used to generate the
   first column of the tableau.
   "
-  [prepare merge present points]
+  [prepare merge points]
   (let [next-col (fn [previous-col]
                    (map merge
                         previous-col
-                        (rest previous-col)))
-        tableau (->> (map prepare points)
-                     (iterate next-col)
-                     (take-while seq))]
-    (present
-     (map first tableau))))
+                        (rest previous-col)))]
+    (->> (map prepare points)
+         (iterate next-col)
+         (take-while seq))))
+
+;; Redefine `neville-merge` to make it slightly more efficient, with baked-in
+;; native operations:
 
 (defn- neville-merge
   "Returns a tableau merge function. Identical to `neville-combine-fn` but uses
@@ -356,6 +355,16 @@
                   (* (- xl x) pr))
                (- xl xr))]
       [xl xr p])))
+
+;; And now, `neville`, identical to `neville-incremental*` except using the
+;; generic tableau generator.
+;;
+;; The form of the tableau also makes it easy to select a particular /column/
+;; instead of just the first row. Columns are powerful because they allow you to
+;; successively interpolate between pairs, triplets etc of points, instead of
+;; moving onto very high order polynomials.
+;;
+;; I'm not sure it's the best interface, but we'll add that arity here.
 
 (defn neville
   "Takes:
@@ -368,22 +377,50 @@
   estimate.
 
   Said another way: the Nth in the returned sequence is the estimate using a
-  polynomial generated from the first N points of the input sequence.
+  polynomial generated from the first N points of the input sequence:
+
+  p0 p01 p012 p0123 p01234
 
   This function generates each estimate using Neville's algorithm:
 
   $$P(x) = [(x - x_r) P_l(x) - (x - x_l) P_r(x)] / [x_l - x_r]$$
+
+  ## Column
+
+  If you supply an integer for the third `column` argument, `neville` will
+  return that /column/ of the interpolation tableau instead of the first row.
+  This will give you a sequence of nth-order polynomial approximations taken
+  between point `i` and the next `n` points.
+
+  As a reminder, this is the shape of the tableau:
+
+   p0 p01 p012 p0123 p01234
+   p1 p12 p123 p1234 .
+   p2 p23 p234 .     .
+   p3 p34 .    .     .
+   p4 .   .    .     .
+
+  So supplying a `column` of `1` gives a sequence of linear approximations
+  between pairs of points; `2` gives quadratic approximations between successive
+  triplets, etc.
 
   References:
 
   - Press's Numerical Recipes (p103), chapter 3: http://phys.uri.edu/nigh/NumRec/bookfpdf/f3-1.pdf
   - Wikipedia: https://en.wikipedia.org/wiki/Neville%27s_algorithm
   "
-  [points x]
-  (tableau-fn neville-prepare
-              (neville-merge x)
-              neville-present
-              points))
+  ([points x]
+   (neville-present
+    (first-terms
+     (tableau-fn neville-prepare
+                 (neville-merge x)
+                 points))))
+  ([points x column]
+   (-> (tableau-fn neville-prepare
+                   (neville-merge x)
+                   points)
+       (nth column)
+       (neville-present))))
 
 ;; ## Modified Neville
 ;;
@@ -470,6 +507,10 @@
   See the `neville` docstring for usage information, and info about the required
   structure of the arguments.
 
+  The structure of the `modified-neville` algorithm makes it difficult to select
+  a particular column. See `neville` if you'd like to generate polynomial
+  approximations between successive sequences of points.
+
   References:
 
   - \"A comparison of algorithms for polynomial interpolation\", A. Macleod,
@@ -477,10 +518,11 @@
   - Press's Numerical Recipes (p103), chapter 3: http://phys.uri.edu/nigh/NumRec/bookfpdf/f3-1.pdf
   "
   [points x]
-  (tableau-fn mn-prepare
-              (mn-merge x)
-              mn-present
-              points))
+  (mn-present
+   (first-terms
+    (tableau-fn mn-prepare
+                (mn-merge x)
+                points))))
 
 ;; ## Folds and Tableaus by Row
 ;;

--- a/src/sicmutils/numerical/interpolate/richardson.cljc
+++ b/src/sicmutils/numerical/interpolate/richardson.cljc
@@ -182,20 +182,20 @@
   columns."
   ([xs t] (make-tableau xs t (iterate inc 1)))
   ([xs t ps]
-   (iterate (fn [[xs [p & ps]]]
-              [(accelerate-sequence xs t p) ps])
-            [xs ps])))
+   (->> (iterate (fn [[xs [p & ps]]]
+                   [(accelerate-sequence xs t p) ps])
+                 [xs ps])
+        (map first)
+        (take-while seq))))
 
 ;; All we really care about are the FIRST terms of each sequence. These
 ;; approximate the sequence's final value with small and smaller error (see the
-;; paper for details:)
-
-(defn- first-terms-of-tableau
-  "The extra `first` inside exists because each tableau column holds the sequence
-  AND the remaining `ps` entries."
-  [tableau]
-  (map (comp first first) tableau))
-
+;; paper for details).
+;;
+;; Polynomial interpolation in `polynomial.cljc` has a similar tableau
+;; structure (not by coincidence!), so we can use `ip/first-terms` in the
+;; implementation below to fetch this first row.
+;;
 ;; Now we can put it all together into a sequence transforming function, with
 ;; nice docs:
 
@@ -256,10 +256,10 @@
   - Wikipedia: https://en.wikipedia.org/wiki/Richardson_extrapolation
   - GJS, 'Abstraction in Numerical Methods': https://dspace.mit.edu/bitstream/handle/1721.1/6060/AIM-997.pdf?sequence=2"
   ([xs t]
-   (first-terms-of-tableau
+   (ip/first-terms
     (make-tableau xs t)))
   ([xs t p-sequence]
-   (first-terms-of-tableau
+   (ip/first-terms
     (make-tableau xs t p-sequence)))
   ([xs t p q]
    (let [arithmetic-p-q (iterate #(+ q %) p)]
@@ -279,6 +279,51 @@
 
 ;; Much faster!
 ;;
+;; ## Richardson Columns
+;;
+;; Richardson extrapolation works by cancelling terms in the error terms of a
+;; function's taylor expansion about `0`. To cancel the nth error term, the nth
+;; derivative has to be defined. Non-smooth functions aren't going to play well
+;; with `richardson-sequence` above.
+;;
+;; The solution is to look at specific /columns/ of the Richardson tableau. Each
+;; column is a sequence with one further error term cancelled.
+;;
+;; `rational.cljc` and `polynomial.cljc` both have this feature in their
+;; tableau-based interpolation functions. The feature here requires a different
+;; function, because the argument vector is a bit crowded already in
+;; `richardson-sequence` above.
+
+(defn richardson-column
+  "Function with an identical interface to `richardson-sequence` above, except for
+  an additional first argument `col`.
+
+  `richardson-column` will return that /column/ offset the interpolation tableau
+  instead of the first row. This will give you a sequence of nth-order
+  Richardson accelerations taken between point `i` and the next `n` points.
+
+  As a reminder, this is the shape of the Richardson tableau:
+
+   p0 p01 p012 p0123 p01234
+   p1 p12 p123 p1234 .
+   p2 p23 p234 .     .
+   p3 p34 .    .     .
+   p4 .   .    .     .
+
+  So supplying a `column` of `1` gives a single acceleration by combining points
+  from column 0; `2` kills two terms from the error sequence, etc.
+
+  NOTE Given a better interface for `richardson-sequence`, this function could
+  be merged with that function."
+  ([col xs t]
+   (nth (make-tableau xs t) col))
+  ([col xs t p-seq]
+   (nth (make-tableau xs t p-seq) col))
+  ([col xs t p q]
+   (let [arithmetic-p-q (iterate #(+ q %) p)]
+     (richardson-column col xs t arithmetic-p-q))))
+
+
 ;; ## Richardson Extrapolation and Polynomial Extrapolation
 ;;
 ;; It turns out that the Richardson extrapolation is a special case of

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -1,5 +1,5 @@
 ;;
-;; Copyright © 2017 Colin Smith.
+;; Copyright © 2020 Sam Ritchie.
 ;; This work is based on the Scmutils system of MIT/GNU Scheme:
 ;; Copyright © 2002 Massachusetts Institute of Technology
 ;;

--- a/test/sicmutils/numerical/interpolate/richardson_test.cljc
+++ b/test/sicmutils/numerical/interpolate/richardson_test.cljc
@@ -42,6 +42,14 @@
                 (-> (ir/richardson-sequence pi-seq 2 2 2)
                     (us/seq-limit {:tolerance v/machine-epsilon}))))
 
+      (is (ish? {:converged? false
+                 :terms-checked 3
+                 :result 3.1415903931299374}
+                (-> (take 3 pi-seq)
+                    (ir/richardson-sequence 2 2 2)
+                    (us/seq-limit {:tolerance v/machine-epsilon})))
+          "richardson-sequence bails if the input sequence runs out of terms.")
+
       (is (ish? [2.8284271247461903
                  3.1391475703122276
                  3.1415903931299374


### PR DESCRIPTION
This PR:

- adds the ability to select specific columns from the tableau methods. This is important for recreating Simpson's method, etc, from the more general methods.
- fixes a bug where Richardson extrapolation would returns an endless sequence of `nil` if its input seq ran out.

brace yourself for more integral PRs!