### PR TITLE
Small fixes, default expt, sub, div implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "scripts": {
-        "test": "shadow-cljs compile test && node target/main/node-tests.js;",
-        "watch-test": "shadow-cljs watch test;"
+  "scripts": {
+    "test": "shadow-cljs compile test && node target/main/node-tests.js;",
+    "watch-test": "shadow-cljs watch test;"
   },
   "dependencies": {
     "complex.js": "^2.0.11",

--- a/src/sicmutils/CHANGELOG.md
+++ b/src/sicmutils/CHANGELOG.md
@@ -14,6 +14,14 @@ this resulted in a few upgrades along the way:
 
 Here are more explicit details on the release.
 
+### Misc
+
+`generic.cljc` now includes a default implementation of:
+
+- `expt` given a valid `mul`
+- default `sub`, given a valid `add` and `negate`
+- default `div`, given a valid `mul` and `invert`
+
 ### Clojurescript Support
 
 Full conversion of SICMUtils to Clojurescript. All functionality from v0.12.1

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -34,6 +34,10 @@
   (freeze [_] (v/freeze expression))
   (kind [_] type))
 
+#?(:clj
+   (defmethod print-method Expression [^Expression s ^java.io.Writer w]
+     (.write w (.toString s))))
+
 (defn literal-number
   [expression]
   (if (number? expression)

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -88,13 +88,13 @@
 (defmethod negative? :default [a] (< a (v/zero-like a)))
 
 (def-generic-function sub 2)
-(defmethod sub :default [a b] (add a (negate a)))
+(defmethod sub :default [a b] (add a (negate b)))
 
 (def-generic-function mul 2)
 (def-generic-function invert 1)
 
 (def-generic-function div 2)
-(defmethod div :default [a] (mul a (invert a)))
+(defmethod div :default [a b] (mul a (invert b)))
 
 (def-generic-function exp 1)
 (def-generic-function log 1)

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -21,7 +21,8 @@
   (:refer-clojure :rename {mod core-mod}
                   :exclude [/ + - * divide #?(:cljs mod)])
   (:require [sicmutils.value :as v]
-            [sicmutils.expression :as x])
+            [sicmutils.expression :as x]
+            [sicmutils.util :as u])
   #?(:cljs (:require-macros [sicmutils.generic :refer [def-generic-function]]))
   #?(:clj
      (:import [clojure.lang LazySeq PersistentVector Symbol Seqable Var])))
@@ -79,15 +80,21 @@
 
 ;; Numeric functions.
 (def-generic-function add 2)
-(def-generic-function mul 2)
-(def-generic-function sub 2)
-(def-generic-function div 2)
 (def-generic-function negate 1)
 (def-generic-function negative? 1
   "Returns true if the argument `a` is less than `(v/zero-like a), false
   otherwise. The default implementation depends on a proper Comparable
   implementation on the type.`")
 (defmethod negative? :default [a] (< a (v/zero-like a)))
+
+(def-generic-function sub 2)
+(defmethod sub :default [a b] (add a (negate a)))
+
+(def-generic-function mul 2)
+(def-generic-function invert 1)
+
+(def-generic-function div 2)
+(defmethod div :default [a] (mul a (invert a)))
 
 (def-generic-function exp 1)
 (def-generic-function log 1)
@@ -106,6 +113,25 @@
       (add m b))))
 
 (def-generic-function expt 2)
+(defmethod expt :default [s e]
+  {:pre [(v/native-integral? e)]}
+  (let [kind (v/kind s)]
+    (if-let [mul' (get-method mul [kind kind])]
+      (letfn [(expt' [base pow]
+                (loop [n pow
+                       y (v/one-like base)
+                       z base]
+                  (let [t (even? n)
+                        n (quot n 2)]
+                    (cond
+                      t (recur n y (mul' z z))
+                      (zero? n) (mul' z y)
+                      :else (recur n (mul' z y) (mul' z z))))))]
+        (cond (pos? e)  (expt' s e)
+              (zero? e) (v/one-like e)
+              :else (invert (expt' s (negate e)))))
+      (u/illegal (str "No g/mul implementation registered for kind " kind)))))
+
 (def-generic-function gcd 2)
 (def-generic-function lcm 2)
 (def-generic-function exact-divide 2)
@@ -125,7 +151,6 @@
 (def-generic-function atan [1 2])
 
 ;; Operations on structures
-(def-generic-function invert 1)
 (def-generic-function transpose 1)
 (def-generic-function magnitude 1)
 (def-generic-function determinant 1)

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -203,20 +203,20 @@
      ;; Implementation of exponent taken from Clojure's numeric tower's
      ;; expt-int:
      ;; https://github.com/clojure/math.numeric-tower/blob/master/src/main/clojure/clojure/math/numeric_tower.clj#L72
-     (letfn [(goog-expt [base pow]
+     (letfn [(long-expt [base pow]
                (loop [^Long n pow
-                      ^Long y (v/one-like base)
+                      ^Long y (.getOne Long)
                       ^Long z base]
-                 (let [t (not (.isOdd ^Long n))
-                       n (.shiftRight ^Long n 1)]
+                 (let [t (not (.isOdd n))
+                       n ^Long (.shiftRight n 1)]
                    (cond
                      t (recur n y (.multiply z z))
-                     (v/nullity? n) (.multiply z y)
+                     (.isZero n) (.multiply z y)
                      :else (recur n (.multiply z y) (.multiply z z))))))]
        (defmethod g/expt [Long Long] [a ^Long b]
          (if (.isNegative b)
-           (g/invert (goog-expt a (.negate b)))
-           (goog-expt a b))))
+           (g/invert (long-expt a (.negate b)))
+           (long-expt a b))))
 
      ;; Compatibility between basic number type and the google numeric types.
      ;; Any operation between a number and a Long or Integer will promote the
@@ -237,20 +237,20 @@
      (defmethod g/remainder [Integer Integer] [^Integer a ^Integer b] (.modulo a b))
      (defmethod g/magnitude [Integer] [^Integer a] (if (.isNegative a) (.negate a) a))
 
-     (letfn [(goog-expt [base pow]
-               (loop [n pow
-                      y (v/one-like base)
-                      z base]
-                 (let [t (not (.isOdd ^Integer n))
-                       n (.shiftRight ^Integer n 1)]
+     (letfn [(int-expt [base pow]
+               (loop [^Integer n pow
+                      ^Integer y (.-ONE Integer)
+                      ^Integer z base]
+                 (let [t (not (.isOdd n))
+                       ^Integer n (.shiftRight n 1)]
                    (cond
                      t (recur n y (.multiply z z))
-                     (v/nullity? n) (.multiply z y)
+                     (.isZero n) (.multiply z y)
                      :else (recur n (.multiply z y) (.multiply z z))))))]
        (defmethod g/expt [Integer Integer] [a ^Integer b]
          (if (.isNegative b)
-           (g/invert (goog-expt a (.negate b)))
-           (goog-expt a b))))
+           (g/invert (int-expt a (.negate b)))
+           (int-expt a b))))
 
      ;; Compatibility between basic number type and the google numeric types.
      ;; Any operation between a number and a Long or Integer will promote the

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -87,9 +87,9 @@
 #?(:clj
    (do
      (derive Number ::number)
-     (derive Double ::floating-pont)
-     (derive Float ::floating-pont)
-     (derive BigDecimal ::floating-pont)
+     (derive Double ::floating-point)
+     (derive Float ::floating-point)
+     (derive BigDecimal ::floating-point)
      (derive Integer ::native-integral)
      (derive Long ::native-integral)
      (derive BigInt ::native-integral)

--- a/test/sicmutils/calculus/vector_field_test.cljc
+++ b/test/sicmutils/calculus/vector_field_test.cljc
@@ -24,6 +24,7 @@
              #?@(:cljs [:include-macros true])]
             [sicmutils.calculus.derivative :refer [D partial]]
             [sicmutils.calculus.manifold :as m :refer [R2-rect R3-cyl R3-rect]]
+            [sicmutils.calculus.form-field :as ff]
             [sicmutils.calculus.vector-field :as vf]
             [sicmutils.function :as f]
             [sicmutils.generic :as g :refer [cos sin + - * /]]
@@ -61,10 +62,6 @@
                 (g/simplify
                  ((((vf/evolution 6) 'a circular) (m/chart R2-rect))
                   ((m/point R2-rect) (up 1 0))))))))))
-
-  (testing "naming"
-    (let-coordinates [[x y] R2-rect]
-      (is (= 0 ))))
 
   (testing "gjs-examples"
     (let-coordinates [[x y z] R3-rect]

--- a/test/sicmutils/sicm/ch5_test.cljc
+++ b/test/sicmutils/sicm/ch5_test.cljc
@@ -26,7 +26,6 @@
                      p->r s->m F->CT
                      literal-function]
              #?@(:cljs [:include-macros true])]
-            [sicmutils.series :as series]
             [sicmutils.mechanics.hamilton :as H]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
 

--- a/test/sicmutils/sicm/ch6_test.cljc
+++ b/test/sicmutils/sicm/ch6_test.cljc
@@ -24,7 +24,6 @@
              :refer [+ - * / D simplify compose
                      up down
                      sin cos square exp]]
-            [sicmutils.series :as series]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.util :as u]))
 


### PR DESCRIPTION
This PR:

- adds a default implementation of `expt` based on a valid `mul`, `kind` and `one-like` implementation
- adds a default `sub`, based on `add` and `negate`
- default `div` if `mul` and `invert` are present

I was inspired by Doug McIlroy's gentle boast that these come for free in Haskell, and realized that we should make it easier for folks to implement these methods too.