### PR TITLE
more sqrt simplifications

### DIFF
--- a/src/sicmutils/CHANGELOG.md
+++ b/src/sicmutils/CHANGELOG.md
@@ -3,10 +3,15 @@
 ##  [Unreleased]
 
 - expose `bootstrap-repl!` to Clojurescript, so that this is available in
-  self-hosted CLJS.
+  self-hosted CLJS (https://github.com/littleredcomputer/sicmutils/pull/157)
 - modified `infix.cljc` to wrap forms in `displaystyle` and add proper carriage
-  returns inside structures.
-- add `multidimensional-minimize` to the `sicmutils.env` namespace.
+  returns inside structures
+  (https://github.com/littleredcomputer/sicmutils/pull/157)
+- add `multidimensional-minimize` to the `sicmutils.env` namespace
+  (https://github.com/littleredcomputer/sicmutils/pull/157)
+- add more `sqrt` simplification rules to allow square roots to cancel out
+  across a division boundary, with or without products in the numerator and
+  denominator (https://github.com/littleredcomputer/sicmutils/pull/160)
 
 ## 0.13.0
 

--- a/src/sicmutils/rules.cljc
+++ b/src/sicmutils/rules.cljc
@@ -80,11 +80,44 @@
     (sqrt (expt :x (:? n even-integer?)))
     => (expt :x (:? #(/ (% 'n) 2)))
 
+    (expt (sqrt :x) (:? n odd-integer?))
+    => (* (sqrt :x) (expt :x (:? #(/ (- (% 'n) 1) 2))))
+
+    (/ :x (sqrt :x)) => (sqrt :x)
+
+    (/ (sqrt :x) :x) => (/ 1 (sqrt :x))
+
+    (/ (* :u* :x :v*) (sqrt :x))
+    =>
+    (* :u* (sqrt :x) :v*)
+
+    (/ (* :u* (sqrt :x) :v*) :x)
+    =>
+    (/ (* :u* :v*) (sqrt :x))
+
+    (/ :x (* :u* (sqrt :x) :v*))
+    =>
+    (/ (sqrt :x) (* :u* :v*))
+
+    (/ (sqrt :x) (* :u* :x :v*))
+    =>
+    (/ 1 (* :u* (sqrt :x) :v*))
+
+    (/ (* :p* :x :q*)
+       (* :u* (sqrt :x) :v*))
+    =>
+    (/ (* :p* (sqrt :x) :q*)
+       (* :u* :v*))
+
+    (/ (* :p* (sqrt :x) :q*)
+       (* :u* :x :v*))
+    =>
+    (/ (* :p* :q*)
+       (* :u* (sqrt :x) :v*))
+
     ;; Following are the new rules we added to approach
     ;; the simplification of the time-invariant-canonical
     ;; test.
-    (expt (sqrt :x) (:? n odd-integer?))
-    => (* (sqrt :x) (expt :x (:? #(/ (- (% 'n) 1) 2))))
 
     ;; ... (sqrt a) ... (sqrt b) ... => ... (sqrt a b)
     (* :f1* (sqrt :a) :f2* (sqrt :b) :f3*)

--- a/test/sicmutils/rules_test.cljc
+++ b/test/sicmutils/rules_test.cljc
@@ -18,7 +18,7 @@
 ;
 
 (ns sicmutils.rules-test
-  (:require [clojure.test :refer [is deftest]]
+  (:require [clojure.test :refer [is deftest testing]]
             [sicmutils.rules :as r]))
 
 (deftest simplify-square-roots-test
@@ -26,7 +26,37 @@
     (is (= '(expt x 4) (s '(expt (sqrt x) 8))))
     (is (= '(* (sqrt x) (expt x 3)) (s '(expt (sqrt x) 7))))
     (is (= '(expt x 4) (s '(sqrt (expt x 8)))))
-    (is (= '(sqrt (expt x 7)) (s '(sqrt (expt x 7)))))))
+    (is (= '(sqrt (expt x 7)) (s '(sqrt (expt x 7)))))
+
+    (testing "simplify across division boundary"
+      (testing "no products, straight division"
+        (is (= '(sqrt x) (s '(/ x (sqrt x)))))
+        (is (= '(/ 1 (sqrt x)) (s '(/ (sqrt x) x)))))
+
+      (testing "product on top only"
+        (is (= '(* 2 (sqrt x) 3)
+               (s '(/ (* 2 x 3) (sqrt x)))))
+        (is (= '(/ (* 2 3) (sqrt x))
+               (s '(/ (* 2 (sqrt x) 3) x)))))
+
+      (testing "product on bottom only"
+        (is (= '(/ 1 (* 2 (sqrt x) 3))
+               (s '(/ (sqrt x) (* 2 x 3)))))
+        (is (= '(/ (sqrt x) (* 2 3))
+               (s '(/ x (* 2 (sqrt x) 3))))))
+
+      (testing "product in num, denom"
+        (is (= '(/ (* 2 (sqrt x) 3)
+                   (* y z))
+               (s '(/ (* 2 x 3)
+                      (* y z (sqrt x)))))
+            "sqrt on bottom")
+
+        (is (= '(/ (* 2 3)
+                   (* y z (sqrt x)))
+               (s '(/ (* 2 (sqrt x) 3)
+                      (* y z x))))
+            "sqrt on top")))))
 
 (deftest divide-numbers-through-test
   (let [d r/divide-numbers-through]


### PR DESCRIPTION
This PR adds more `sqrt` simplification rules to allow square roots to cancel out across a division boundary, with or without products in the numerator and denominator.