### PR TITLE
Speed up power series multiplication

### DIFF
--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -189,10 +189,12 @@
 (defn seq:* [f g]
   (letfn [(step [f]
             (lazy-seq
-             (let [f*g  (g/mul (first f) (first g))
-                   f*G1 (c*seq (first f) (rest g))
-                   F1*G (step (rest f))]
-               (cons f*g (seq:+ f*G1 F1*G)))))]
+             (if (v/nullity? (first f))
+               (cons (first f) (step (rest f)))
+               (let [f*g  (g/mul (first f) (first g))
+                     f*G1 (c*seq (first f) (rest g))
+                     F1*G (step (rest f))]
+                 (cons f*g (seq:+ f*G1 F1*G))))))]
     (step f)))
 
 ;; This works just fine on two infinite sequences:

--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -195,7 +195,10 @@
                      f*G1 (c*seq (first f) (rest g))
                      F1*G (step (rest f))]
                  (cons f*g (seq:+ f*G1 F1*G))))))]
-    (step f)))
+    (lazy-seq
+     (if (v/nullity? (first g))
+       (cons (first g) (seq:* f (rest g)))
+       (step f)))))
 
 ;; This works just fine on two infinite sequences:
 

--- a/test/sicmutils/series/impl_test.cljc
+++ b/test/sicmutils/series/impl_test.cljc
@@ -122,7 +122,13 @@
   (testing "expt"
     (is (= (take 11 (i/binomial 10))
            (take 11 (i/expt (i/->series [1 1]) 10)))
-        "(1 + x)^10 = binomial expansion"))
+        "(1 + x)^10 = binomial expansion")
+
+    (let [s (i/->series [1 0 3 1])]
+      (is (= (take 13 (i/seq:* (i/seq:* s s)
+                               (i/seq:* s s)))
+             (take 13 (i/expt s 4)))
+          "(1 + 3x^2 + x^3)^4, expt matches mul")))
 
   (testing "series sqrt"
     (let [xs (iterate inc 1)]


### PR DESCRIPTION
I was playing around to see if I could speed this up by generating the binomial series directly in the exponent code... and it looks like no, it's plenty fast now with a `zero?` check added in the mult method.